### PR TITLE
Fix: 메뉴바에서 페이지 이동 시 메뉴바 비활성화, Search탭 비활성화 시 색 추가, Search 메뉴 아이콘 선택 시 메뉴바 활성화

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -27,6 +27,7 @@ export default function Menu({
 
   const movePage = (e: React.MouseEvent<HTMLLIElement>) => {
     const span = e.currentTarget.dataset.value;
+    setOnMenu(false);
     if (span === "HOME") {
       navigate("/main/home");
     } else if (span === "SEARCH") {

--- a/src/css/components/menu.module.css
+++ b/src/css/components/menu.module.css
@@ -22,6 +22,7 @@
   flex-direction: column;
   padding: 20px 10px 40px 20px;
   box-sizing: border-box;
+  z-index: 999;
 }
 .menuDiv.show {
   transform: translateX(0);

--- a/src/css/pages/search.module.css
+++ b/src/css/pages/search.module.css
@@ -135,7 +135,10 @@
   background-color: rgba(198, 108, 217, 0.2);
   border-radius: 10px;
   padding: 0 6px;
-  text-align: center;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
   margin-left: 3px;
 }
 .selected {
@@ -143,6 +146,9 @@
 }
 .default {
   color: #8f8f8f;
+}
+.defaultCnt {
+  background-color: #ebebeb;
 }
 /* 검색 후 공연, 밴드 선택 카테고리 */
 

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -68,7 +68,7 @@ export default function Search() {
           setOnMenu={setOnMenu}
           setAnimateMenu={setAnimateMenu}
         />
-      )}  
+      )}
       <div className={searchStyle.fixedDiv}>
         <div className={searchStyle.inputDiv}>
           <img
@@ -112,7 +112,9 @@ export default function Search() {
               </span>
               <span
                 className={`${searchStyle.count} ${
-                  onFestival ? searchStyle.selected : searchStyle.default
+                  onFestival
+                    ? searchStyle.selected
+                    : `${searchStyle.default} ${searchStyle.defaultCnt}`
                 }     `}
               >
                 159
@@ -133,7 +135,9 @@ export default function Search() {
               </span>
               <span
                 className={`${searchStyle.count} ${
-                  !onFestival ? searchStyle.selected : searchStyle.default
+                  !onFestival
+                    ? searchStyle.selected
+                    : `${searchStyle.default} ${searchStyle.defaultCnt}`
                 }`}
               >
                 1

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -5,11 +5,14 @@ import xSVG from "../assets/pages/search/x.svg";
 import heartSVG from "../assets/pages/search/heart.svg";
 import arrowSVG from "../assets/pages/search/arrow-right.svg";
 import { useEffect, useState } from "react";
+import Menu from "../components/Menu";
 
 export default function Search() {
   const [inputText, setInputText] = useState<string>("");
   const [isSearch, setIsSearch] = useState<boolean>(true);
   const [onFestival, setOnFestival] = useState<boolean>(true);
+  const [onMenu, setOnMenu] = useState<boolean>(false);
+  const [animateMenu, setAnimateMenu] = useState<boolean>(false);
   const recommendLista: any[] = [
     {
       id: 1,
@@ -59,6 +62,13 @@ export default function Search() {
   }, [inputText]);
   return (
     <>
+      {onMenu && (
+        <Menu
+          animateMenu={animateMenu}
+          setOnMenu={setOnMenu}
+          setAnimateMenu={setAnimateMenu}
+        />
+      )}  
       <div className={searchStyle.fixedDiv}>
         <div className={searchStyle.inputDiv}>
           <img
@@ -76,7 +86,14 @@ export default function Search() {
             }}
             onKeyDown={handleEnter}
           />
-          <img src={menuSVG} alt="메뉴" className={searchStyle.menuIcon} />
+          <img
+            src={menuSVG}
+            alt="메뉴"
+            className={searchStyle.menuIcon}
+            onClick={() => {
+              setOnMenu(true);
+            }}
+          />
         </div>
         {isSearch && (
           <div className={searchStyle.festivalAndBand}>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #32 

## 📝작업 내용

- 메뉴바에서 페이지 이동 시 페이지 비활성화
```typescript
const movePage = (e: React.MouseEvent<HTMLLIElement>) => {
    const span = e.currentTarget.dataset.value;
    setOnMenu(false);
    if (span === "HOME") {
      navigate("/main/home");
    } else if (span === "SEARCH") {
      navigate("/search");
    } else if (span === "TIME TABLE") {
      navigate("/main/timetable");
    } else if (span === "MY BANDS") {
      navigate("/main/mybands");
    } else if (span === "MY CONCERTS") {
      navigate("/main/myconcerts");
    }
  };
```
페이지 이동 전  `setOnMenu(false);` 해주었습니다.

<br>

- Search 탭 비활성화 시 색 추가
```typescript
<span
                className={`${searchStyle.count} ${
                  onFestival
                    ? searchStyle.selected
                    : `${searchStyle.default} ${searchStyle.defaultCnt}`
                }     `}
              >
                159
              </span>
```
비활성화될 때 `defaultCnt `클래스명 추가 해줬습니다.

<br>

- Search 메뉴 아이콘 선택 시 메뉴바 활성화
```typescript
{onMenu && (
        <Menu
          animateMenu={animateMenu}
          setOnMenu={setOnMenu}
          setAnimateMenu={setAnimateMenu}
        />
      )}
```
추가해줬습니다.

### 스크린샷 (선택)





## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ❌ 이슈 닫기

- close #32 