### PR TITLE
Fix: Recommend Card 횡 스크롤 수정

### DIFF
--- a/src/css/components/timetable/festivallistitem.module.css
+++ b/src/css/components/timetable/festivallistitem.module.css
@@ -46,6 +46,7 @@
   width: 11px;
   height: 11px;
   aspect-ratio: 1/1;
+  cursor:pointer;
 }
 
 .heartCount,

--- a/src/css/components/timetable/recommendcard.module.css
+++ b/src/css/components/timetable/recommendcard.module.css
@@ -7,20 +7,13 @@
 
 .cardThumbnail {
   display: flex;
-  width: 132px;
-  height: 176px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   aspect-ratio: 3/4;
 }
 
-.cardThumbnail img {
-  width: 132px;
-  height: 176px;
-  aspect-ratio: 3/4;
-  position: absolute;
-}
+
 
 .cardInfo {
   margin-bottom: 8px;

--- a/src/css/pages/timetable/timetablemain.module.css
+++ b/src/css/pages/timetable/timetablemain.module.css
@@ -48,6 +48,7 @@
   letter-spacing: -0.3px;
   position: relative;
   padding-left: 6px;
+  cursor: pointer;
 }
 
 .sortButton::before {

--- a/src/css/pages/timetable/timetablemain.module.css
+++ b/src/css/pages/timetable/timetablemain.module.css
@@ -22,6 +22,7 @@
   gap: 16px;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  min-width: 375px;
 }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #39 

## 📝작업 내용
<img width="415" height="378" alt="스크린샷 2025-11-18 오후 2 58 34" src="https://github.com/user-attachments/assets/9a1fa19d-e4de-4b21-a8bb-f66e64b26f2c" />
 횡 스크롤 시 이미지는 넘어가지않으며, 부모 컴포넌트의 css 설정으로 인해 
recommend card 가 잘리는 문제를 해결하였습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ❌ 이슈 닫기

> ex) close #39 