### PR TITLE
Feat: Timetable 세부페이지 UI 구현 및 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2815,6 +2816,7 @@
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2825,6 +2827,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2899,6 +2902,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -3151,6 +3155,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3410,6 +3415,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4020,6 +4026,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5917,6 +5924,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5926,6 +5934,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6726,6 +6735,7 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -6780,6 +6790,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6933,6 +6944,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7116,6 +7128,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7240,6 +7253,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7538,6 +7552,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7582,6 +7597,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.13.2",
+        "html2canvas": "^1.4.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
@@ -3361,6 +3362,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.25",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
@@ -3643,6 +3653,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -4772,6 +4791,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/idb": {
@@ -6749,6 +6781,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7120,6 +7161,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.13.2",
+    "html2canvas": "^1.4.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,8 @@ export default function App() {
          <Route path="concert/:mt20id" element={<ConcertProfile />} />
           <Route path="timetable">
             <Route index element={<TimetableMainPage />} />
-            <Route path=":id" element={<TimetableDetailPage />} />
+            <Route path="customize/:id" element={<TimetableDetailPage />} />
+            <Route path="my/:id" element={<TimetableDetailPage />} />
           </Route>
         </Route>
         <Route path="search" element={<Search />} />

--- a/src/assets/timetable/arrow-down.svg
+++ b/src/assets/timetable/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.5 3.75L5 6.25L7.5 3.75" stroke="#D1D1D1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/timetable/arrow-left.svg
+++ b/src/assets/timetable/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="28" viewBox="0 0 24 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 21L9 14L15 7" stroke="#1A1A1A" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/timetable/download.svg
+++ b/src/assets/timetable/download.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.5 12.5V15.8333C17.5 16.2754 17.3244 16.6993 17.0118 17.0118C16.6993 17.3244 16.2754 17.5 15.8333 17.5H4.16667C3.72464 17.5 3.30072 17.3244 2.98816 17.0118C2.67559 16.6993 2.5 16.2754 2.5 15.8333V12.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.83325 8.33337L9.99992 12.5L14.1666 8.33337" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 12.5V2.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/timetable/refresh.svg
+++ b/src/assets/timetable/refresh.svg
@@ -1,0 +1,12 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_83_2491)">
+<path d="M0.833252 3.33337V8.33337H5.83325" stroke="#D32323" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.1666 16.6666V11.6666H14.1666" stroke="#D32323" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.0749 7.49998C16.6523 6.30564 15.934 5.23782 14.987 4.39616C14.0401 3.55451 12.8954 2.96645 11.6597 2.68686C10.424 2.40727 9.13762 2.44527 7.92059 2.79729C6.70356 3.14932 5.59554 3.80391 4.69992 4.69998L0.833252 8.33331M19.1666 11.6666L15.2999 15.3C14.4043 16.1961 13.2963 16.8506 12.0792 17.2027C10.8622 17.5547 9.57584 17.5927 8.34016 17.3131C7.10447 17.0335 5.95975 16.4455 5.01281 15.6038C4.06586 14.7621 3.34756 13.6943 2.92492 12.5" stroke="#D32323" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_83_2491">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/timetable/FestivalListItem.tsx
+++ b/src/components/timetable/FestivalListItem.tsx
@@ -1,51 +1,39 @@
 // src/components/timetable/FestivalListItem.tsx
 
-import { useState } from 'react'; // ⭐️ 1. useState import 추가 ⭐️
-import { useNavigate } from 'react-router-dom'; 
+import { useState } from 'react';
 import festivalListStyles from "../../css/components/timetable/festivallistitem.module.css"; 
 import sampleposter from "../../assets/timetable/poster.svg"; 
 import arrowIconSVG from "../../assets/timetable/arrow-right.svg"; 
+import heartFilled from "../../assets/timetable/heart.svg";
+import heartEmpty from "../../assets/timetable/heart-empty.svg";
 
-
-import heartFilled from "../../assets/timetable/heart.svg";    // 채워진 하트 (기존 heart.svg 사용)
-import heartEmpty from "../../assets/timetable/heart-empty.svg"; // 빈 하트 이미지 경로 가정 (파일 준비 필요)
-
-interface FestivalItemData {
-    id: number;
-    title: string;
-    likes: number;
-    location: string;
-    date: string;
-    thumbnailUrl: string;
-}
+// ⭐️ 수정: 'import type'을 명시적으로 사용합니다. ⭐️
+import type { FestivalItem } from "../../pages/timetable/TimetableMainPage"; 
 
 interface FestivalListItemProps {
-    itemData: FestivalItemData;
+    itemData: FestivalItem; 
+    onClick: (festivalId: number) => void; 
 }
 
 
-export default function FestivalListItem({ itemData }: FestivalListItemProps) {
+export default function FestivalListItem({ itemData, onClick }: FestivalListItemProps) {
     
-    const navigate = useNavigate();
-    // ⭐️ 3. 좋아요 상태를 관리하는 로컬 state 추가 (초기값: false) ⭐️
     const [isLiked, setIsLiked] = useState(false); 
 
     const handleNavigation = () => {
-        navigate(`main/timetable/${itemData.id}`); 
+        onClick(itemData.id); 
     };
 
-    // ⭐️ 4. 하트 클릭 핸들러 추가 ⭐️
     const handleHeartClick = (event: React.MouseEvent) => {
-        event.stopPropagation(); // li 태그의 클릭 이벤트(상세 페이지 이동) 전파 방지
-        setIsLiked(prev => !prev); // 상태 토글 (false -> true, true -> false)
-        
-        // *참고: 만약 이 시점에 상위 컴포넌트나 API로 좋아요 상태를 알려야 한다면 여기에 로직이 추가됩니다.
+        event.stopPropagation();
+        setIsLiked(prev => !prev);
     };
 
 
     return (
         <li 
             className={festivalListStyles.timetableListItem} 
+            onClick={handleNavigation} 
         >
             <img 
                 src={sampleposter} 
@@ -57,18 +45,16 @@ export default function FestivalListItem({ itemData }: FestivalListItemProps) {
                 
                 <div 
                     className={festivalListStyles.listTitle}
-                    onClick={handleNavigation} // 타이틀 클릭 시 상세 이동
                 >
                     {itemData.title}
                 </div>
                 
                 <div className={festivalListStyles.listDetails}>
                     <img 
-                        // ⭐️ 5. isLiked 상태에 따라 이미지 동적 선택 ⭐️
                         src={isLiked ? heartFilled : heartEmpty} 
                         alt="좋아요 아이콘" 
                         className={festivalListStyles.heartIcon} 
-                        onClick={handleHeartClick} // ⭐️ 6. 클릭 핸들러 연결 ⭐️
+                        onClick={handleHeartClick}
                     />
                     <span className={festivalListStyles.heartCount}>{itemData.likes}</span>
                     <span className={festivalListStyles.divider}></span> 
@@ -82,7 +68,6 @@ export default function FestivalListItem({ itemData }: FestivalListItemProps) {
                 src={arrowIconSVG} 
                 alt="상세 페이지 이동" 
                 className={festivalListStyles.arrowIcon}
-                onClick={handleNavigation} // 화살표 클릭 시 상세 이동
             />
             
         </li>

--- a/src/components/timetable/FestivalListItem.tsx
+++ b/src/components/timetable/FestivalListItem.tsx
@@ -1,4 +1,4 @@
-// src/components/timetable/FestivalListItem.tsx (최종 수정본 - 좋아요 개수 로직 제거)
+// src/components/timetable/FestivalListItem.tsx (최종 수정본 - ID/NewState 전달)
 
 import { useState, useEffect } from 'react';
 import festivalListStyles from "../../css/components/timetable/festivallistitem.module.css"; 
@@ -12,20 +12,19 @@ import axios from 'axios';
 interface FestivalListItemProps {
     itemData: FestivalItem; 
     onClick: (festivalId: number) => void; 
-    onLikeChangeSuccess: () => void;
+    // ⭐️⭐️ [수정] onLikeChangeSuccess의 시그니처를 변경: ID와 새로운 isLiked 상태를 전달 ⭐️⭐️
+    onLikeChangeSuccess: (festivalId: number, newIsLikedState: boolean) => void;
 }
 
 
 export default function FestivalListItem({ itemData, onClick, onLikeChangeSuccess }: FestivalListItemProps) {
     
-    // ⭐️ 좋아요 개수 (likeCount) 관련 상태 제거 ⭐️
     const [isLiked, setIsLiked] = useState(itemData.isLiked); 
 
     // Props가 변경될 때 내부 상태를 동기화합니다. (서버 응답 반영)
     useEffect(() => {
         setIsLiked(itemData.isLiked);
-        // setLikeCount(isNaN(itemData.likeCount) ? 0 : itemData.likeCount); // ⭐️ 제거 ⭐️
-    }, [itemData.isLiked /* itemData.likeCount 제거 */]);
+    }, [itemData.isLiked]);
 
 
     const handleNavigation = () => {
@@ -36,57 +35,46 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
         event.stopPropagation();
         
         // 1. 낙관적 업데이트 및 이전 상태 저장
-        const previousIsLiked = isLiked; // ⭐️⭐️⭐️ 토글 전 원래 상태를 저장 ⭐️⭐️⭐️
-        // const previousLikeCount = likeCount; // ⭐️ 제거 ⭐️
-
-        // ⭐️ 디버깅 로그 1: 함수 진입 확인
-        console.log(`[CLICK START] ID: ${itemData.id}, 이전 좋아요 상태: ${previousIsLiked}`); // 카운트 로그 제거
+        const previousIsLiked = isLiked; 
+        const newIsLikedState = !previousIsLiked; // ⭐️⭐️ 토글 후 예상되는 상태 ⭐️⭐️
 
         // UI를 즉시 변경 (낙관적 업데이트)
-        setIsLiked(prev => !prev);
-        // setLikeCount(prev => prev + (previousIsLiked ? -1 : 1)); // ⭐️ 제거 ⭐️
+        setIsLiked(newIsLikedState);
+        console.log(`[CLICK START] ID: ${itemData.id}, 이전 좋아요 상태: ${previousIsLiked}, UI 즉시 ${newIsLikedState}로 업데이트`);
 
         try {
             // ⭐️⭐️ 핵심 수정: 토글 전 상태인 previousIsLiked를 사용 ⭐️⭐️
             if (previousIsLiked) { // 이전 상태가 좋아요(true)였으면 -> 취소(DELETE)를 시도
-                console.log(`[API CALL] DELETE /likes/performances/${itemData.id} 호출 직전`);
                 await cancelLikePerformance(itemData.id); 
             } else { // 이전 상태가 비좋아요(false)였으면 -> 등록(POST)을 시도
-                console.log(`[API CALL] POST /likes/performances/${itemData.id} 호출 직전`);
                 await likePerformance(itemData.id);
             }
             
-            // ⭐️ 디버깅 로그 2: API 성공 확인
-            console.log(`[API SUCCESS] 요청 성공. 부모 목록 새로고침 호출.`);
-            // 2. 성공: 부모에게 목록 새로고침 요청
-            onLikeChangeSuccess(); 
+            console.log(`[API SUCCESS] 요청 성공. ID: ${itemData.id}, 최종 상태: ${newIsLikedState}`);
+            
+            // 2. 성공: 부모에게 항목 ID와 최종 상태(newIsLikedState)를 전달
+            // ⭐️⭐️ [핵심 수정] ID와 최종 상태를 부모에게 전달하여 로컬 목록 업데이트를 지시 ⭐️⭐️
+            onLikeChangeSuccess(itemData.id, newIsLikedState); 
 
         } catch (error) {
             // 3. 실패 시 처리 및 롤백
             let errorMessage = '좋아요 처리 중 알 수 없는 오류가 발생했습니다.';
-            let needsRollback = true; // 롤백 여부 플래그
+            let needsRollback = true; 
             
             if (axios.isAxiosError(error) && error.response) {
                 const status = error.response.status;
                 errorMessage = (error.response.data as any)?.message || errorMessage;
                 
-                // 4. 롤백 불필요 (서버 상태와 UI 일치) - 카운트 관련 로직 제거
-                if (status === 409 && !previousIsLiked) { 
-                    // setLikeCount(previousLikeCount); // ⭐️ 제거 ⭐️
-                    needsRollback = false; // UI는 채워진 상태로 유지 (서버와 일치)
-                } 
-                else if (status === 404 && previousIsLiked) { 
-                    // setLikeCount(previousLikeCount); // ⭐️ 제거 ⭐️
-                    needsRollback = false; // UI는 빈 상태로 유지 (서버와 일치)
+                // 4. 롤백 불필요 (서버 상태와 UI 일치): POST 409 (이미 있음), DELETE 404 (이미 없음)
+                if ((status === 409 && !previousIsLiked) || (status === 404 && previousIsLiked)) { 
+                    needsRollback = false; 
                 }
             }
             
             // 5. 롤백 실행
             if (needsRollback) {
-                // ⭐️ 디버깅 로그 3: 롤백 실행 확인
-                console.log(`[ROLLBACK] API 실패 (needsRollback=true). 이전 상태로 복구.`);
+                console.log(`[ROLLBACK] API 실패. 이전 상태 ${previousIsLiked}로 복구.`);
                 setIsLiked(previousIsLiked);
-                // setLikeCount(previousLikeCount); // ⭐️ 제거 ⭐️
             }
 
             console.error(`❌ 좋아요 토글 실패 (ID: ${itemData.id}):`, errorMessage);
@@ -115,7 +103,6 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
                 </div>
                 
                 <div className={festivalListStyles.listDetails}>
-                    {/* ⭐️ 하트 아이콘과 감싸는 span 태그 유지 ⭐️ */}
                     <span> <img 
                         src={isLiked ? heartFilled : heartEmpty} 
                         alt="좋아요 아이콘" 
@@ -123,8 +110,6 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
                         onClick={handleHeartClick}
                     /></span>
                    
-                    {/* <span className={festivalListStyles.heartCount}>...</span> */} {/* ⭐️ 제거 ⭐️ */}
-                    
                     <span className={festivalListStyles.divider}></span> 
                     <span className={festivalListStyles.location}>{itemData.location}</span>
                     <span className={festivalListStyles.divider}></span> 

--- a/src/components/timetable/FestivalListItem.tsx
+++ b/src/components/timetable/FestivalListItem.tsx
@@ -1,8 +1,6 @@
-// src/components/timetable/FestivalListItem.tsx
-
 import { useState } from 'react';
 import festivalListStyles from "../../css/components/timetable/festivallistitem.module.css"; 
-import sampleposter from "../../assets/timetable/poster.svg"; 
+// import sampleposter from "../../assets/timetable/poster.svg"; // ⭐️ 이 줄을 제거하거나 주석 처리합니다. ⭐️
 import arrowIconSVG from "../../assets/timetable/arrow-right.svg"; 
 import heartFilled from "../../assets/timetable/heart.svg";
 import heartEmpty from "../../assets/timetable/heart-empty.svg";
@@ -35,8 +33,11 @@ export default function FestivalListItem({ itemData, onClick }: FestivalListItem
             className={festivalListStyles.timetableListItem} 
             onClick={handleNavigation} 
         >
+            {/* ⭐️ 수정: src 속성을 itemData.thumbnailUrl로 변경 ⭐️
+                이 itemData.thumbnailUrl은 TimetableMainPage에서 item.poster를 매핑한 값입니다.
+            */}
             <img 
-                src={sampleposter} 
+                src={itemData.thumbnailUrl} // ⭐️ 이 부분을 수정했습니다. ⭐️
                 alt={`${itemData.title} 포스터`} 
                 className={festivalListStyles.listThumbnail} 
             />
@@ -50,6 +51,7 @@ export default function FestivalListItem({ itemData, onClick }: FestivalListItem
                 </div>
                 
                 <div className={festivalListStyles.listDetails}>
+                    {/* ... (나머지 좋아요, 위치, 날짜 정보는 그대로 유지) ... */}
                     <img 
                         src={isLiked ? heartFilled : heartEmpty} 
                         alt="좋아요 아이콘" 

--- a/src/components/timetable/FestivalListItem.tsx
+++ b/src/components/timetable/FestivalListItem.tsx
@@ -6,7 +6,7 @@ import festivalListStyles from "../../css/components/timetable/festivallistitem.
 import sampleposter from "../../assets/timetable/poster.svg"; 
 import arrowIconSVG from "../../assets/timetable/arrow-right.svg"; 
 
-// ⭐️ 2. 두 가지 하트 이미지 import ⭐️
+
 import heartFilled from "../../assets/timetable/heart.svg";    // 채워진 하트 (기존 heart.svg 사용)
 import heartEmpty from "../../assets/timetable/heart-empty.svg"; // 빈 하트 이미지 경로 가정 (파일 준비 필요)
 
@@ -31,7 +31,7 @@ export default function FestivalListItem({ itemData }: FestivalListItemProps) {
     const [isLiked, setIsLiked] = useState(false); 
 
     const handleNavigation = () => {
-        navigate(`/timetable/detail/${itemData.id}`); 
+        navigate(`main/timetable/${itemData.id}`); 
     };
 
     // ⭐️ 4. 하트 클릭 핸들러 추가 ⭐️

--- a/src/components/timetable/FestivalListItem.tsx
+++ b/src/components/timetable/FestivalListItem.tsx
@@ -1,4 +1,4 @@
-// src/components/timetable/FestivalListItem.tsx (최종 수정본 - 로직 오류 해결)
+// src/components/timetable/FestivalListItem.tsx (최종 수정본 - 좋아요 개수 로직 제거)
 
 import { useState, useEffect } from 'react';
 import festivalListStyles from "../../css/components/timetable/festivallistitem.module.css"; 
@@ -18,15 +18,14 @@ interface FestivalListItemProps {
 
 export default function FestivalListItem({ itemData, onClick, onLikeChangeSuccess }: FestivalListItemProps) {
     
-    const initialLikeCount = isNaN(itemData.likeCount) ? 0 : itemData.likeCount;
+    // ⭐️ 좋아요 개수 (likeCount) 관련 상태 제거 ⭐️
     const [isLiked, setIsLiked] = useState(itemData.isLiked); 
-    const [likeCount, setLikeCount] = useState(initialLikeCount); 
 
     // Props가 변경될 때 내부 상태를 동기화합니다. (서버 응답 반영)
     useEffect(() => {
         setIsLiked(itemData.isLiked);
-        setLikeCount(isNaN(itemData.likeCount) ? 0 : itemData.likeCount);
-    }, [itemData.isLiked, itemData.likeCount]);
+        // setLikeCount(isNaN(itemData.likeCount) ? 0 : itemData.likeCount); // ⭐️ 제거 ⭐️
+    }, [itemData.isLiked /* itemData.likeCount 제거 */]);
 
 
     const handleNavigation = () => {
@@ -38,14 +37,14 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
         
         // 1. 낙관적 업데이트 및 이전 상태 저장
         const previousIsLiked = isLiked; // ⭐️⭐️⭐️ 토글 전 원래 상태를 저장 ⭐️⭐️⭐️
-        const previousLikeCount = likeCount;
+        // const previousLikeCount = likeCount; // ⭐️ 제거 ⭐️
 
         // ⭐️ 디버깅 로그 1: 함수 진입 확인
-        console.log(`[CLICK START] ID: ${itemData.id}, 이전 좋아요 상태: ${previousIsLiked}, 이전 카운트: ${previousLikeCount}`);
+        console.log(`[CLICK START] ID: ${itemData.id}, 이전 좋아요 상태: ${previousIsLiked}`); // 카운트 로그 제거
 
         // UI를 즉시 변경 (낙관적 업데이트)
         setIsLiked(prev => !prev);
-        setLikeCount(prev => prev + (previousIsLiked ? -1 : 1)); // isLiked 대신 previousIsLiked 사용
+        // setLikeCount(prev => prev + (previousIsLiked ? -1 : 1)); // ⭐️ 제거 ⭐️
 
         try {
             // ⭐️⭐️ 핵심 수정: 토글 전 상태인 previousIsLiked를 사용 ⭐️⭐️
@@ -65,20 +64,20 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
         } catch (error) {
             // 3. 실패 시 처리 및 롤백
             let errorMessage = '좋아요 처리 중 알 수 없는 오류가 발생했습니다.';
-            let needsRollback = true;
+            let needsRollback = true; // 롤백 여부 플래그
             
             if (axios.isAxiosError(error) && error.response) {
                 const status = error.response.status;
                 errorMessage = (error.response.data as any)?.message || errorMessage;
                 
-                // 4. 롤백 불필요 (서버 상태와 UI 일치)
+                // 4. 롤백 불필요 (서버 상태와 UI 일치) - 카운트 관련 로직 제거
                 if (status === 409 && !previousIsLiked) { 
-                    setLikeCount(previousLikeCount); 
-                    needsRollback = false; 
+                    // setLikeCount(previousLikeCount); // ⭐️ 제거 ⭐️
+                    needsRollback = false; // UI는 채워진 상태로 유지 (서버와 일치)
                 } 
                 else if (status === 404 && previousIsLiked) { 
-                    setLikeCount(previousLikeCount); 
-                    needsRollback = false; 
+                    // setLikeCount(previousLikeCount); // ⭐️ 제거 ⭐️
+                    needsRollback = false; // UI는 빈 상태로 유지 (서버와 일치)
                 }
             }
             
@@ -87,7 +86,7 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
                 // ⭐️ 디버깅 로그 3: 롤백 실행 확인
                 console.log(`[ROLLBACK] API 실패 (needsRollback=true). 이전 상태로 복구.`);
                 setIsLiked(previousIsLiked);
-                setLikeCount(previousLikeCount);
+                // setLikeCount(previousLikeCount); // ⭐️ 제거 ⭐️
             }
 
             console.error(`❌ 좋아요 토글 실패 (ID: ${itemData.id}):`, errorMessage);
@@ -116,15 +115,16 @@ export default function FestivalListItem({ itemData, onClick, onLikeChangeSucces
                 </div>
                 
                 <div className={festivalListStyles.listDetails}>
-                    <img 
+                    {/* ⭐️ 하트 아이콘과 감싸는 span 태그 유지 ⭐️ */}
+                    <span> <img 
                         src={isLiked ? heartFilled : heartEmpty} 
                         alt="좋아요 아이콘" 
                         className={festivalListStyles.heartIcon} 
                         onClick={handleHeartClick}
-                    />
-                    <span className={festivalListStyles.heartCount}>
-                        {isNaN(likeCount) ? 0 : likeCount}
-                    </span>
+                    /></span>
+                   
+                    {/* <span className={festivalListStyles.heartCount}>...</span> */} {/* ⭐️ 제거 ⭐️ */}
+                    
                     <span className={festivalListStyles.divider}></span> 
                     <span className={festivalListStyles.location}>{itemData.location}</span>
                     <span className={festivalListStyles.divider}></span> 

--- a/src/components/timetable/FestivalListItem.tsx
+++ b/src/components/timetable/FestivalListItem.tsx
@@ -1,30 +1,98 @@
-import { useState } from 'react';
+// src/components/timetable/FestivalListItem.tsx (최종 수정본 - 로직 오류 해결)
+
+import { useState, useEffect } from 'react';
 import festivalListStyles from "../../css/components/timetable/festivallistitem.module.css"; 
-// import sampleposter from "../../assets/timetable/poster.svg"; // ⭐️ 이 줄을 제거하거나 주석 처리합니다. ⭐️
 import arrowIconSVG from "../../assets/timetable/arrow-right.svg"; 
 import heartFilled from "../../assets/timetable/heart.svg";
 import heartEmpty from "../../assets/timetable/heart-empty.svg";
-
-// ⭐️ 수정: 'import type'을 명시적으로 사용합니다. ⭐️
 import type { FestivalItem } from "../../pages/timetable/TimetableMainPage"; 
+import { likePerformance, cancelLikePerformance } from "../../api/performanceLike";
+import axios from 'axios'; 
 
 interface FestivalListItemProps {
     itemData: FestivalItem; 
     onClick: (festivalId: number) => void; 
+    onLikeChangeSuccess: () => void;
 }
 
 
-export default function FestivalListItem({ itemData, onClick }: FestivalListItemProps) {
+export default function FestivalListItem({ itemData, onClick, onLikeChangeSuccess }: FestivalListItemProps) {
     
-    const [isLiked, setIsLiked] = useState(false); 
+    const initialLikeCount = isNaN(itemData.likeCount) ? 0 : itemData.likeCount;
+    const [isLiked, setIsLiked] = useState(itemData.isLiked); 
+    const [likeCount, setLikeCount] = useState(initialLikeCount); 
+
+    // Props가 변경될 때 내부 상태를 동기화합니다. (서버 응답 반영)
+    useEffect(() => {
+        setIsLiked(itemData.isLiked);
+        setLikeCount(isNaN(itemData.likeCount) ? 0 : itemData.likeCount);
+    }, [itemData.isLiked, itemData.likeCount]);
+
 
     const handleNavigation = () => {
         onClick(itemData.id); 
     };
 
-    const handleHeartClick = (event: React.MouseEvent) => {
+    const handleHeartClick = async (event: React.MouseEvent) => {
         event.stopPropagation();
+        
+        // 1. 낙관적 업데이트 및 이전 상태 저장
+        const previousIsLiked = isLiked; // ⭐️⭐️⭐️ 토글 전 원래 상태를 저장 ⭐️⭐️⭐️
+        const previousLikeCount = likeCount;
+
+        // ⭐️ 디버깅 로그 1: 함수 진입 확인
+        console.log(`[CLICK START] ID: ${itemData.id}, 이전 좋아요 상태: ${previousIsLiked}, 이전 카운트: ${previousLikeCount}`);
+
+        // UI를 즉시 변경 (낙관적 업데이트)
         setIsLiked(prev => !prev);
+        setLikeCount(prev => prev + (previousIsLiked ? -1 : 1)); // isLiked 대신 previousIsLiked 사용
+
+        try {
+            // ⭐️⭐️ 핵심 수정: 토글 전 상태인 previousIsLiked를 사용 ⭐️⭐️
+            if (previousIsLiked) { // 이전 상태가 좋아요(true)였으면 -> 취소(DELETE)를 시도
+                console.log(`[API CALL] DELETE /likes/performances/${itemData.id} 호출 직전`);
+                await cancelLikePerformance(itemData.id); 
+            } else { // 이전 상태가 비좋아요(false)였으면 -> 등록(POST)을 시도
+                console.log(`[API CALL] POST /likes/performances/${itemData.id} 호출 직전`);
+                await likePerformance(itemData.id);
+            }
+            
+            // ⭐️ 디버깅 로그 2: API 성공 확인
+            console.log(`[API SUCCESS] 요청 성공. 부모 목록 새로고침 호출.`);
+            // 2. 성공: 부모에게 목록 새로고침 요청
+            onLikeChangeSuccess(); 
+
+        } catch (error) {
+            // 3. 실패 시 처리 및 롤백
+            let errorMessage = '좋아요 처리 중 알 수 없는 오류가 발생했습니다.';
+            let needsRollback = true;
+            
+            if (axios.isAxiosError(error) && error.response) {
+                const status = error.response.status;
+                errorMessage = (error.response.data as any)?.message || errorMessage;
+                
+                // 4. 롤백 불필요 (서버 상태와 UI 일치)
+                if (status === 409 && !previousIsLiked) { 
+                    setLikeCount(previousLikeCount); 
+                    needsRollback = false; 
+                } 
+                else if (status === 404 && previousIsLiked) { 
+                    setLikeCount(previousLikeCount); 
+                    needsRollback = false; 
+                }
+            }
+            
+            // 5. 롤백 실행
+            if (needsRollback) {
+                // ⭐️ 디버깅 로그 3: 롤백 실행 확인
+                console.log(`[ROLLBACK] API 실패 (needsRollback=true). 이전 상태로 복구.`);
+                setIsLiked(previousIsLiked);
+                setLikeCount(previousLikeCount);
+            }
+
+            console.error(`❌ 좋아요 토글 실패 (ID: ${itemData.id}):`, errorMessage);
+            alert(`좋아요 처리 실패: ${errorMessage}`);
+        }
     };
 
 
@@ -33,11 +101,8 @@ export default function FestivalListItem({ itemData, onClick }: FestivalListItem
             className={festivalListStyles.timetableListItem} 
             onClick={handleNavigation} 
         >
-            {/* ⭐️ 수정: src 속성을 itemData.thumbnailUrl로 변경 ⭐️
-                이 itemData.thumbnailUrl은 TimetableMainPage에서 item.poster를 매핑한 값입니다.
-            */}
             <img 
-                src={itemData.thumbnailUrl} // ⭐️ 이 부분을 수정했습니다. ⭐️
+                src={itemData.thumbnailUrl} 
                 alt={`${itemData.title} 포스터`} 
                 className={festivalListStyles.listThumbnail} 
             />
@@ -51,14 +116,15 @@ export default function FestivalListItem({ itemData, onClick }: FestivalListItem
                 </div>
                 
                 <div className={festivalListStyles.listDetails}>
-                    {/* ... (나머지 좋아요, 위치, 날짜 정보는 그대로 유지) ... */}
                     <img 
                         src={isLiked ? heartFilled : heartEmpty} 
                         alt="좋아요 아이콘" 
                         className={festivalListStyles.heartIcon} 
                         onClick={handleHeartClick}
                     />
-                    <span className={festivalListStyles.heartCount}>{itemData.likes}</span>
+                    <span className={festivalListStyles.heartCount}>
+                        {isNaN(likeCount) ? 0 : likeCount}
+                    </span>
                     <span className={festivalListStyles.divider}></span> 
                     <span className={festivalListStyles.location}>{itemData.location}</span>
                     <span className={festivalListStyles.divider}></span> 

--- a/src/components/timetable/RecommendCard.tsx
+++ b/src/components/timetable/RecommendCard.tsx
@@ -1,20 +1,19 @@
-// src/components/timetable/RecommendCard.tsx
+// src/components/timetable/RecommendCard.tsx (이미지 소스 수정)
 
 import cardstyles from "../../css/components/timetable/recommendcard.module.css"; 
-import concertImage from "../../assets/timetable/concert_image.svg"
+// import concertImage from "../../assets/timetable/concert_image.svg" // ⭐️ 제거: itemData에서 URL 받음 ⭐️
 
 interface RecommendCardProps {
     itemData: {
         id: number;
         title: string;
         date: string;
-        thumbnailUrl: string;
+        thumbnailUrl: string; // ⭐️ 사용될 이미지 URL ⭐️
     };
     onCustomizeClick: (id: number) => void; 
 }
 
 const RecommendCard = ({ itemData, onCustomizeClick }: RecommendCardProps) => {
-    
     const handleClick = () => {
         onCustomizeClick(itemData.id); 
     };
@@ -22,8 +21,9 @@ const RecommendCard = ({ itemData, onCustomizeClick }: RecommendCardProps) => {
     return (
         <div className={cardstyles.recommendCard}>
             
-            <div className={cardstyles.cardThumbnail}>
-                <img src={concertImage} alt={`${itemData.title} 포스터`} />
+            <div>
+                {/* ⭐️ [수정] 이미지 소스를 itemData.thumbnailUrl로 교체 ⭐️ */}
+                <img src={itemData.thumbnailUrl} className={cardstyles.cardThumbnail}alt={`${itemData.title} 포스터`} />
             </div>
             
             <div className={cardstyles.cardInfo}>

--- a/src/components/timetable/ScheduleBlock.tsx
+++ b/src/components/timetable/ScheduleBlock.tsx
@@ -1,0 +1,53 @@
+// src/components/timetable/ScheduleBlock.tsx
+
+import React, { useMemo } from 'react';
+import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage';
+import blockStyles from '../../css/components/timetable/scheduleblock.module.css';
+
+interface ScheduleBlockProps {
+    schedule: ScheduleItem;
+    startTimeMinutes: number; 
+    mode: 'customize' | 'my' | 'view';
+}
+
+const timeToMinutes = (time: string): number => {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
+};
+
+const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ schedule, startTimeMinutes, mode }) => {
+    
+    const style = useMemo(() => {
+        
+        const scheduleStartMinutes = timeToMinutes(schedule.start);
+        const minutesFromStart = scheduleStartMinutes - startTimeMinutes;
+        
+        const top = (minutesFromStart / 10) * 20;
+        const height = (schedule.minutes / 10) * 20;
+        
+        // stageOrder를 2로 나눈 나머지에 따라 색상을 번갈아 가며 부여
+        const colorIndex = schedule.stageOrder % 2; 
+        let blockColorClass = colorIndex === 1 
+            ? blockStyles.colorYellow 
+            : blockStyles.colorPurple; 
+            
+        return { top: `${top}px`, height: `${height}px`, blockColorClass };
+    }, [schedule, startTimeMinutes, mode]);
+
+
+    const timeRange = `${schedule.start.substring(0, 5)}-${schedule.end.substring(0, 5)}`;
+
+    return (
+        <div 
+            className={`${blockStyles.scheduleBlock} ${style.blockColorClass}`} 
+            style={{ top: style.top, height: style.height }}
+            onClick={() => console.log(`Clicked ${schedule.artist} (Mode: ${mode})`)}
+        >
+            <div className={blockStyles.artist}>{schedule.artist}</div>
+            <div className={blockStyles.time}>{timeRange}</div>
+            <div className={blockStyles.duration}>({schedule.minutes}분)</div>
+        </div>
+    );
+};
+
+export default ScheduleBlock;

--- a/src/components/timetable/ScheduleBlock.tsx
+++ b/src/components/timetable/ScheduleBlock.tsx
@@ -1,5 +1,3 @@
-// src/components/timetable/ScheduleBlock.tsx (수정된 코드: 상태 위임)
-
 import React, { useMemo } from 'react';
 import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage';
 import blockStyles from '../../css/components/timetable/scheduleblock.module.css';
@@ -8,11 +6,7 @@ interface ScheduleBlockProps {
     schedule: ScheduleItem;
     startTimeMinutes: number; 
     mode: 'customize' | 'my' | 'view';
-    
-    // ⭐️ (추가) 활성화 상태를 부모로부터 받습니다. ⭐️
     isActive: boolean;
-    
-    // ⭐️ (추가) 클릭 시 부모에게 상태 변경을 알릴 콜백 함수를 받습니다. ⭐️
     onToggle: (schedule: ScheduleItem) => void; 
 }
 
@@ -23,13 +17,10 @@ const timeToMinutes = (time: string): number => {
 
 const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ 
     schedule, 
-    startTimeMinutes, 
-    mode, 
-    // ⭐️ (수정) Props를 구조 분해 할당하고, 기존 useState를 제거합니다. ⭐️
+    startTimeMinutes,  
     isActive, 
     onToggle 
 }) => {
-    // ⭐️ (제거) 로컬 상태 useState(active) 제거 ⭐️
 
     const style = useMemo(() => {
         const scheduleStartMinutes = timeToMinutes(schedule.start);
@@ -38,7 +29,6 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({
         const top = (minutesFromStart / 10) * 20;
         const height = (schedule.minutes / 10) * 20;
 
-        // ⭐️ (수정) isActive Props를 사용하여 색상을 결정합니다. ⭐️
         let blockColorClass = isActive
             ? schedule.stageOrder === 1
                 ? blockStyles.colorStage1
@@ -51,9 +41,8 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({
                 : schedule.stageOrder === 5
                 ? blockStyles.colorStage5
                 : blockStyles.colorStage4
-            : blockStyles.colorInactive; // 초기 상태 회색 (비활성화)
+            : blockStyles.colorInactive;
 
-        // ⭐️ (수정) useMemo의 의존성 배열에 isActive를 추가합니다. ⭐️
         return { top: `${top}px`, height: `${height}px`, blockColorClass };
     }, [schedule, startTimeMinutes, isActive]);
 
@@ -63,7 +52,6 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({
         <div 
             className={`${blockStyles.scheduleBlock} ${style.blockColorClass}`} 
             style={{ top: style.top, height: style.height }}
-            // ⭐️ (수정) 클릭 시 부모 컴포넌트의 onToggle 함수를 호출하고, 자신의 schedule 정보를 전달합니다. ⭐️
             onClick={() => onToggle(schedule)}
         >
             <div className={blockStyles.artist}>{schedule.artist}</div>

--- a/src/components/timetable/ScheduleBlock.tsx
+++ b/src/components/timetable/ScheduleBlock.tsx
@@ -1,6 +1,4 @@
-// src/components/timetable/ScheduleBlock.tsx
-
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage';
 import blockStyles from '../../css/components/timetable/scheduleblock.module.css';
 
@@ -16,32 +14,36 @@ const timeToMinutes = (time: string): number => {
 };
 
 const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ schedule, startTimeMinutes, mode }) => {
-    
+    const [active, setActive] = useState(false); // 클릭 상태
+
     const style = useMemo(() => {
-        
         const scheduleStartMinutes = timeToMinutes(schedule.start);
         const minutesFromStart = scheduleStartMinutes - startTimeMinutes;
-        
+
         const top = (minutesFromStart / 10) * 20;
         const height = (schedule.minutes / 10) * 20;
-        
-        // stageOrder를 2로 나눈 나머지에 따라 색상을 번갈아 가며 부여
-        const colorIndex = schedule.stageOrder % 2; 
-        let blockColorClass = colorIndex === 1 
-            ? blockStyles.colorYellow 
-            : blockStyles.colorPurple; 
-            
+
+        // 클릭 전 기본 색상
+        let blockColorClass = active
+            ? schedule.stageOrder === 1
+                ? blockStyles.colorStage1
+                : schedule.stageOrder === 2
+                ? blockStyles.colorStage2
+                : schedule.stageOrder === 3
+                ? blockStyles.colorStage3
+                : blockStyles.colorStage4
+            : blockStyles.colorInactive; // 초기 상태 회색
+
         return { top: `${top}px`, height: `${height}px`, blockColorClass };
-    }, [schedule, startTimeMinutes, mode]);
+    }, [schedule, startTimeMinutes, active]);
 
-
-    const timeRange = `${schedule.start.substring(0, 5)}-${schedule.end.substring(0, 5)}`;
+    const timeRange = `${schedule.start.substring(0,5)}-${schedule.end.substring(0,5)}`;
 
     return (
         <div 
             className={`${blockStyles.scheduleBlock} ${style.blockColorClass}`} 
             style={{ top: style.top, height: style.height }}
-            onClick={() => console.log(`Clicked ${schedule.artist} (Mode: ${mode})`)}
+            onClick={() => setActive(prev => !prev)}
         >
             <div className={blockStyles.artist}>{schedule.artist}</div>
             <div className={blockStyles.time}>{timeRange}</div>

--- a/src/components/timetable/ScheduleBlock.tsx
+++ b/src/components/timetable/ScheduleBlock.tsx
@@ -46,6 +46,10 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({
                 ? blockStyles.colorStage2
                 : schedule.stageOrder === 3
                 ? blockStyles.colorStage3
+                : schedule.stageOrder === 4
+                ? blockStyles.colorStage4
+                : schedule.stageOrder === 5
+                ? blockStyles.colorStage5
                 : blockStyles.colorStage4
             : blockStyles.colorInactive; // 초기 상태 회색 (비활성화)
 

--- a/src/components/timetable/ScheduleBlock.tsx
+++ b/src/components/timetable/ScheduleBlock.tsx
@@ -1,4 +1,6 @@
-import React, { useMemo, useState } from 'react';
+// src/components/timetable/ScheduleBlock.tsx (수정된 코드: 상태 위임)
+
+import React, { useMemo } from 'react';
 import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage';
 import blockStyles from '../../css/components/timetable/scheduleblock.module.css';
 
@@ -6,6 +8,12 @@ interface ScheduleBlockProps {
     schedule: ScheduleItem;
     startTimeMinutes: number; 
     mode: 'customize' | 'my' | 'view';
+    
+    // ⭐️ (추가) 활성화 상태를 부모로부터 받습니다. ⭐️
+    isActive: boolean;
+    
+    // ⭐️ (추가) 클릭 시 부모에게 상태 변경을 알릴 콜백 함수를 받습니다. ⭐️
+    onToggle: (schedule: ScheduleItem) => void; 
 }
 
 const timeToMinutes = (time: string): number => {
@@ -13,8 +21,15 @@ const timeToMinutes = (time: string): number => {
     return h * 60 + m;
 };
 
-const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ schedule, startTimeMinutes, mode }) => {
-    const [active, setActive] = useState(false); // 클릭 상태
+const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ 
+    schedule, 
+    startTimeMinutes, 
+    mode, 
+    // ⭐️ (수정) Props를 구조 분해 할당하고, 기존 useState를 제거합니다. ⭐️
+    isActive, 
+    onToggle 
+}) => {
+    // ⭐️ (제거) 로컬 상태 useState(active) 제거 ⭐️
 
     const style = useMemo(() => {
         const scheduleStartMinutes = timeToMinutes(schedule.start);
@@ -23,8 +38,8 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ schedule, startTimeMinute
         const top = (minutesFromStart / 10) * 20;
         const height = (schedule.minutes / 10) * 20;
 
-        // 클릭 전 기본 색상
-        let blockColorClass = active
+        // ⭐️ (수정) isActive Props를 사용하여 색상을 결정합니다. ⭐️
+        let blockColorClass = isActive
             ? schedule.stageOrder === 1
                 ? blockStyles.colorStage1
                 : schedule.stageOrder === 2
@@ -32,10 +47,11 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ schedule, startTimeMinute
                 : schedule.stageOrder === 3
                 ? blockStyles.colorStage3
                 : blockStyles.colorStage4
-            : blockStyles.colorInactive; // 초기 상태 회색
+            : blockStyles.colorInactive; // 초기 상태 회색 (비활성화)
 
+        // ⭐️ (수정) useMemo의 의존성 배열에 isActive를 추가합니다. ⭐️
         return { top: `${top}px`, height: `${height}px`, blockColorClass };
-    }, [schedule, startTimeMinutes, active]);
+    }, [schedule, startTimeMinutes, isActive]);
 
     const timeRange = `${schedule.start.substring(0,5)}-${schedule.end.substring(0,5)}`;
 
@@ -43,7 +59,8 @@ const ScheduleBlock: React.FC<ScheduleBlockProps> = ({ schedule, startTimeMinute
         <div 
             className={`${blockStyles.scheduleBlock} ${style.blockColorClass}`} 
             style={{ top: style.top, height: style.height }}
-            onClick={() => setActive(prev => !prev)}
+            // ⭐️ (수정) 클릭 시 부모 컴포넌트의 onToggle 함수를 호출하고, 자신의 schedule 정보를 전달합니다. ⭐️
+            onClick={() => onToggle(schedule)}
         >
             <div className={blockStyles.artist}>{schedule.artist}</div>
             <div className={blockStyles.time}>{timeRange}</div>

--- a/src/components/timetable/TimeAxis.tsx
+++ b/src/components/timetable/TimeAxis.tsx
@@ -1,52 +1,21 @@
-// src/components/timetable/TimeAxis.tsx (Stage 3개 고정 및 단순화 버전)
-
 import React from 'react';
 import gridStyles from '../../css/components/timetable/timetablegrid.module.css';
+interface TimeAxisProps { startTimeMinutes:number; endTimeMinutes:number; totalHeightPixels:number }
 
-interface TimeAxisProps {
-    startTimeMinutes: number;
-    endTimeMinutes: number;
-    totalHeightPixels: number;
-}
-
-const TimeAxis: React.FC<TimeAxisProps> = ({ startTimeMinutes, endTimeMinutes, totalHeightPixels }) => {
-
-    const hourMarkers: number[] = [];
-    
-    // 1시간 단위로 마커 생성 (시작 시간의 다음 정시부터 끝 시간까지)
-    for (let m = Math.ceil(startTimeMinutes / 60) * 60; m <= endTimeMinutes; m += 60) {
-        if (m < endTimeMinutes) { 
-             hourMarkers.push(m);
-        }
-    }
-
-    const minutesToTop = (minutes: number) => {
-        const minutesFromStart = minutes - startTimeMinutes;
-        // 10분당 20px (2px/분)
-        return (minutesFromStart / 10) * 20; 
-    };
-
-    const minutesToTimeLabel = (minutes: number) => {
-        const h = Math.floor(minutes / 60);
-        return `${String(h).padStart(2, '0')}`;
-    };
-
-    return (
-        <div className={gridStyles.timeAxis} style={{ height: `${totalHeightPixels}px` }}>
-            {hourMarkers.map((minutes) => {
-                const top = minutesToTop(minutes);
-                return (
-                    <React.Fragment key={minutes}>
-                        <div className={gridStyles.timeLabel} style={{ top: `${top}px` }}>
-                            {minutesToTimeLabel(minutes)}:00
-                        </div>
-                        {/* 횡스크롤 이전 버전에서는 TimeAxis에서 점선을 직접 렌더링했습니다. */}
-                        <div className={gridStyles.timeDivider} style={{ top: `${top}px` }} />
-                    </React.Fragment>
-                );
-            })}
+const TimeAxis:React.FC<TimeAxisProps>=({startTimeMinutes,endTimeMinutes,totalHeightPixels})=>{
+    const hourMarkers:number[]=[];
+    for(let m=Math.ceil(startTimeMinutes/60)*60;m<=endTimeMinutes;m+=60) if(m<endTimeMinutes) hourMarkers.push(m);
+    const minutesToTop=(minutes:number)=>(minutes-startTimeMinutes)/10*20;
+    const minutesToTimeLabel=(minutes:number)=>String(Math.floor(minutes/60)).padStart(2,'0');
+    return(
+        <div className={gridStyles.timeAxis} style={{height:`${totalHeightPixels}px`}}>
+            {hourMarkers.map(minutes=>(
+                <React.Fragment key={minutes}>
+                    <div className={gridStyles.timeLabel} style={{top:`${minutesToTop(minutes)}px`}}>{minutesToTimeLabel(minutes)}:00</div>
+                    <div className={gridStyles.timeDivider} style={{top:`${minutesToTop(minutes)}px`}}/>
+                </React.Fragment>
+            ))}
         </div>
     );
 };
-
 export default TimeAxis;

--- a/src/components/timetable/TimeAxis.tsx
+++ b/src/components/timetable/TimeAxis.tsx
@@ -1,0 +1,52 @@
+// src/components/timetable/TimeAxis.tsx (Stage 3개 고정 및 단순화 버전)
+
+import React from 'react';
+import gridStyles from '../../css/components/timetable/timetablegrid.module.css';
+
+interface TimeAxisProps {
+    startTimeMinutes: number;
+    endTimeMinutes: number;
+    totalHeightPixels: number;
+}
+
+const TimeAxis: React.FC<TimeAxisProps> = ({ startTimeMinutes, endTimeMinutes, totalHeightPixels }) => {
+
+    const hourMarkers: number[] = [];
+    
+    // 1시간 단위로 마커 생성 (시작 시간의 다음 정시부터 끝 시간까지)
+    for (let m = Math.ceil(startTimeMinutes / 60) * 60; m <= endTimeMinutes; m += 60) {
+        if (m < endTimeMinutes) { 
+             hourMarkers.push(m);
+        }
+    }
+
+    const minutesToTop = (minutes: number) => {
+        const minutesFromStart = minutes - startTimeMinutes;
+        // 10분당 20px (2px/분)
+        return (minutesFromStart / 10) * 20; 
+    };
+
+    const minutesToTimeLabel = (minutes: number) => {
+        const h = Math.floor(minutes / 60);
+        return `${String(h).padStart(2, '0')}`;
+    };
+
+    return (
+        <div className={gridStyles.timeAxis} style={{ height: `${totalHeightPixels}px` }}>
+            {hourMarkers.map((minutes) => {
+                const top = minutesToTop(minutes);
+                return (
+                    <React.Fragment key={minutes}>
+                        <div className={gridStyles.timeLabel} style={{ top: `${top}px` }}>
+                            {minutesToTimeLabel(minutes)}:00
+                        </div>
+                        {/* 횡스크롤 이전 버전에서는 TimeAxis에서 점선을 직접 렌더링했습니다. */}
+                        <div className={gridStyles.timeDivider} style={{ top: `${top}px` }} />
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+};
+
+export default TimeAxis;

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -13,6 +13,9 @@ interface TimetableGridProps {
     allSchedules: ScheduleItem[];
     mode: 'customize' | 'my' | 'view';
     
+    // ⭐️ (추가) ⭐️ 토글 처리 함수와 활성화된 키 목록을 받습니다.
+    onScheduleToggle: (schedule: ScheduleItem) => void;
+    activeScheduleKeys: Set<string>; 
 }
 
 const TIME_UNIT_MINUTES = 10; 
@@ -23,7 +26,14 @@ const timeToMinutes = (time: string) => { const [h,m] = time.split(':').map(Numb
 const getStartTimeMinutes = (schedules: ScheduleItem[]) => schedules.length===0?900:Math.floor(Math.min(...schedules.map(s=>timeToMinutes(s.start)))/15)*15;
 
 // ⭐️ Prop 목록에서 stageNames를 제거했습니다. ⭐️
-const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, allSchedules, mode }) => {
+const TimetableGrid: React.FC<TimetableGridProps> = ({ 
+    stageMap, 
+    allSchedules, 
+    mode, 
+    // ⭐️ (추가) ⭐️ 새로 받은 props를 구조 분해 할당
+    onScheduleToggle, 
+    activeScheduleKeys 
+}) => {
     const startTimeMinutes = useMemo(() => getStartTimeMinutes(allSchedules), [allSchedules]);
     const endTimeMinutes = useMemo(() => {
         if(allSchedules.length===0) return startTimeMinutes+120;
@@ -35,6 +45,11 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, allSchedules, m
 
     const stageKeys = Object.keys(stageMap);
     const totalStageCount = stageKeys.length;
+
+    // ⭐️ (추가) ⭐️ ScheduleItem의 고유 키를 생성하는 헬퍼 함수
+    // TimetableDetailPage와 동일하게 정의되어야 합니다.
+    const createScheduleKey = (s: ScheduleItem) => `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
+
 
     return (
         <div className={gridStyles.timetableContainer}>
@@ -57,7 +72,7 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, allSchedules, m
                         }
                         return (
                             <div key={key} className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
-                                LAND STAGE
+                                {key} {/* ⭐️ LAND STAGE 대신 실제 Stage Key(Name) 사용을 권장합니다. ⭐️ */}
                             </div>
                         )
                     })}
@@ -67,9 +82,23 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, allSchedules, m
                 <div className={gridStyles.scheduleArea} style={{ height:`${totalHeightPixels}px`, width:`${totalStageCount*STAGE_WIDTH}px` }}>
                     {stageKeys.map((key,index)=>(
                         <div key={index} className={gridStyles.scheduleColumn} style={{width:`${STAGE_WIDTH}px`}}>
-                            {stageMap[key].map(schedule=>(
-                                <ScheduleBlock key={schedule.start+schedule.artist} schedule={schedule} startTimeMinutes={startTimeMinutes} mode={mode}/>
-                            ))}
+                            {stageMap[key].map(schedule=>{ // ⭐️ (수정) ⭐️ 중괄호를 사용하여 로직 추가
+                                // ⭐️ (추가) ⭐️ ScheduleBlock에 전달할 isActive 상태 결정
+                                const scheduleKey = createScheduleKey(schedule); 
+                                const isActive = activeScheduleKeys.has(scheduleKey);
+
+                                return (
+                                    <ScheduleBlock 
+                                        key={scheduleKey} // ⭐️ (수정) ⭐️ 고유 키 사용
+                                        schedule={schedule} 
+                                        startTimeMinutes={startTimeMinutes} 
+                                        mode={mode}
+                                        // ⭐️ (추가) ⭐️ isActive 상태와 토글 함수 전달
+                                        isActive={isActive} 
+                                        onToggle={onScheduleToggle}
+                                    />
+                                );
+                            })}
                         </div>
                     ))}
                 </div>

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -1,0 +1,130 @@
+// src/components/timetable/TimetableGrid.tsx (Stage 3개 고정 버전)
+
+import React, { useMemo } from 'react';
+import ScheduleBlock from './ScheduleBlock';
+import TimeAxis from './TimeAxis';
+import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage'; 
+import gridStyles from '../../css/components/timetable/timetablegrid.module.css';
+
+interface StageNames {
+    1: string;
+    2: string;
+    3: string;
+}
+
+interface TimetableGridProps {
+    // ⭐️ Stage 3개 고정 Props ⭐️
+    stage1Schedules: ScheduleItem[];
+    stage2Schedules: ScheduleItem[];
+    stage3Schedules: ScheduleItem[];
+    stageNames: StageNames;
+    allSchedules: ScheduleItem[]; // 시간 계산용
+    mode: 'customize' | 'my' | 'view';
+}
+
+// ⭐️ 유틸리티 상수 및 함수 ⭐️
+const TIME_UNIT_MINUTES = 10; 
+const PIXEL_PER_UNIT = 20;    
+
+const timeToMinutes = (time: string): number => {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
+};
+
+const getStartTimeMinutes = (schedules: ScheduleItem[]): number => {
+    if (schedules.length === 0) return 900; 
+    
+    const startTimes = schedules.map(s => timeToMinutes(s.start));
+    const earliestMin = Math.min(...startTimes);
+    
+    // 시작 시간을 15분 단위로 내림하여 그리드 시작점을 맞춤
+    return Math.floor(earliestMin / 15) * 15; 
+};
+
+
+const TimetableGrid: React.FC<TimetableGridProps> = ({ 
+    stage1Schedules, 
+    stage2Schedules, 
+    stage3Schedules, 
+    stageNames, 
+    allSchedules,
+    mode 
+}) => {
+    
+    // ⭐️ 시간 범위 및 높이 계산 ⭐️
+    const startTimeMinutes = useMemo(() => getStartTimeMinutes(allSchedules), [allSchedules]);
+
+    const endTimeMinutes = useMemo(() => {
+        if (allSchedules.length === 0) return startTimeMinutes + 120;
+        const latestEnd = Math.max(...allSchedules.map(s => timeToMinutes(s.end)));
+        // 끝 시간을 정시 다음 60분 단위로 올림하여 여유 공간 확보
+        return Math.ceil((latestEnd + 1) / 60) * 60; 
+    }, [allSchedules, startTimeMinutes]);
+
+    const totalHeightMinutes = endTimeMinutes - startTimeMinutes;
+    const totalHeightPixels = (totalHeightMinutes / TIME_UNIT_MINUTES) * PIXEL_PER_UNIT; 
+    
+    return (
+        <div className={gridStyles.timetableContainer}>
+            
+            <TimeAxis 
+                startTimeMinutes={startTimeMinutes}
+                endTimeMinutes={endTimeMinutes}
+                totalHeightPixels={totalHeightPixels}
+            />
+
+            {/* ⭐️ 횡 스크롤 제거, 고정된 너비 그리드 래퍼 ⭐️ */}
+            <div className={gridStyles.stageGridWrapper}>
+                
+                {/* ⭐️ Stage Header: 3개 고정 ⭐️ */}
+                <div className={gridStyles.stageHeader}>
+                    <div className={gridStyles.stageHeaderBlock}>{stageNames[1]}</div>
+                    <div className={gridStyles.stageHeaderBlock}>{stageNames[2]}</div>
+                    <div className={gridStyles.stageHeaderBlock}>{stageNames[3]}</div>
+                </div>
+
+                {/* Schedule Columns: 3개 고정 */}
+                <div className={gridStyles.scheduleArea} style={{ height: `${totalHeightPixels}px` }}>
+                    
+                    {/* Stage 1 */}
+                    <div className={gridStyles.scheduleColumn}>
+                        {stage1Schedules.map((schedule) => (
+                            <ScheduleBlock
+                                key={schedule.start + schedule.artist}
+                                schedule={schedule}
+                                startTimeMinutes={startTimeMinutes}
+                                mode={mode}
+                            />
+                        ))}
+                    </div>
+
+                    {/* Stage 2 */}
+                    <div className={gridStyles.scheduleColumn}>
+                        {stage2Schedules.map((schedule) => (
+                            <ScheduleBlock
+                                key={schedule.start + schedule.artist}
+                                schedule={schedule}
+                                startTimeMinutes={startTimeMinutes}
+                                mode={mode}
+                            />
+                        ))}
+                    </div>
+                    
+                    {/* Stage 3 */}
+                    <div className={gridStyles.scheduleColumn}>
+                        {stage3Schedules.map((schedule) => (
+                            <ScheduleBlock
+                                key={schedule.start + schedule.artist}
+                                schedule={schedule}
+                                startTimeMinutes={startTimeMinutes}
+                                mode={mode}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default TimetableGrid;

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -1,126 +1,70 @@
-// src/components/timetable/TimetableGrid.tsx (Stage 3개 고정 버전)
+// src/components/timetable/TimetableGrid.tsx (Stage 색상 매핑 + 동적 Stage + 횡스크롤)
 
 import React, { useMemo } from 'react';
 import ScheduleBlock from './ScheduleBlock';
 import TimeAxis from './TimeAxis';
-import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage'; 
+import type { ScheduleItem } from '../../pages/timetable/TimetableDetailPage';
 import gridStyles from '../../css/components/timetable/timetablegrid.module.css';
 
-interface StageNames {
-    1: string;
-    2: string;
-    3: string;
-}
-
 interface TimetableGridProps {
-    // ⭐️ Stage 3개 고정 Props ⭐️
-    stage1Schedules: ScheduleItem[];
-    stage2Schedules: ScheduleItem[];
-    stage3Schedules: ScheduleItem[];
-    stageNames: StageNames;
-    allSchedules: ScheduleItem[]; // 시간 계산용
+    stageMap: Record<string, ScheduleItem[]>; 
+    stageNames: Record<string, string>;
+    allSchedules: ScheduleItem[];
     mode: 'customize' | 'my' | 'view';
 }
 
-// ⭐️ 유틸리티 상수 및 함수 ⭐️
 const TIME_UNIT_MINUTES = 10; 
 const PIXEL_PER_UNIT = 20;    
+const STAGE_WIDTH = 152.5;
 
-const timeToMinutes = (time: string): number => {
-    const [h, m] = time.split(':').map(Number);
-    return h * 60 + m;
-};
+const timeToMinutes = (time: string) => { const [h,m] = time.split(':').map(Number); return h*60+m; };
+const getStartTimeMinutes = (schedules: ScheduleItem[]) => schedules.length===0?900:Math.floor(Math.min(...schedules.map(s=>timeToMinutes(s.start)))/15)*15;
 
-const getStartTimeMinutes = (schedules: ScheduleItem[]): number => {
-    if (schedules.length === 0) return 900; 
-    
-    const startTimes = schedules.map(s => timeToMinutes(s.start));
-    const earliestMin = Math.min(...startTimes);
-    
-    // 시작 시간을 15분 단위로 내림하여 그리드 시작점을 맞춤
-    return Math.floor(earliestMin / 15) * 15; 
-};
-
-
-const TimetableGrid: React.FC<TimetableGridProps> = ({ 
-    stage1Schedules, 
-    stage2Schedules, 
-    stage3Schedules, 
-    stageNames, 
-    allSchedules,
-    mode 
-}) => {
-    
-    // ⭐️ 시간 범위 및 높이 계산 ⭐️
+const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, stageNames, allSchedules, mode }) => {
     const startTimeMinutes = useMemo(() => getStartTimeMinutes(allSchedules), [allSchedules]);
-
     const endTimeMinutes = useMemo(() => {
-        if (allSchedules.length === 0) return startTimeMinutes + 120;
-        const latestEnd = Math.max(...allSchedules.map(s => timeToMinutes(s.end)));
-        // 끝 시간을 정시 다음 60분 단위로 올림하여 여유 공간 확보
-        return Math.ceil((latestEnd + 1) / 60) * 60; 
-    }, [allSchedules, startTimeMinutes]);
+        if(allSchedules.length===0) return startTimeMinutes+120;
+        const latestEnd = Math.max(...allSchedules.map(s=>timeToMinutes(s.end)));
+        return Math.ceil((latestEnd+1)/60)*60;
+    }, [allSchedules,startTimeMinutes]);
 
-    const totalHeightMinutes = endTimeMinutes - startTimeMinutes;
-    const totalHeightPixels = (totalHeightMinutes / TIME_UNIT_MINUTES) * PIXEL_PER_UNIT; 
-    
+    const totalHeightPixels = ((endTimeMinutes-startTimeMinutes)/TIME_UNIT_MINUTES)*PIXEL_PER_UNIT;
+
+    const stageKeys = Object.keys(stageMap);
+
     return (
         <div className={gridStyles.timetableContainer}>
-            
-            <TimeAxis 
-                startTimeMinutes={startTimeMinutes}
-                endTimeMinutes={endTimeMinutes}
-                totalHeightPixels={totalHeightPixels}
-            />
+            <TimeAxis startTimeMinutes={startTimeMinutes} endTimeMinutes={endTimeMinutes} totalHeightPixels={totalHeightPixels}/>
 
-            {/* ⭐️ 횡 스크롤 제거, 고정된 너비 그리드 래퍼 ⭐️ */}
-            <div className={gridStyles.stageGridWrapper}>
-                
-                {/* ⭐️ Stage Header: 3개 고정 ⭐️ */}
-                <div className={gridStyles.stageHeader}>
-                    <div className={gridStyles.stageHeaderBlock}>{stageNames[1]}</div>
-                    <div className={gridStyles.stageHeaderBlock}>{stageNames[2]}</div>
-                    <div className={gridStyles.stageHeaderBlock}>{stageNames[3]}</div>
+            <div className={gridStyles.stageGridWrapper} style={{ overflowX: 'auto', width: `calc(100% + 40px)`, marginLeft: '-20px' }}>
+                {/* Stage Header */}
+                <div className={gridStyles.stageHeader} style={{ width: `${stageKeys.length*STAGE_WIDTH}px` }}>
+                    {stageKeys.map((key,index)=>{
+                        let colorClass = '';
+                        switch(index+1){
+                            case 1: colorClass = gridStyles.colorStage1; break;
+                            case 2: colorClass = gridStyles.colorStage2; break;
+                            case 3: colorClass = gridStyles.colorStage3; break;
+                            case 4: colorClass = gridStyles.colorStage4; break;
+                            default: colorClass = gridStyles.colorStage1;
+                        }
+                        return (
+                            <div key={key} className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
+                                {stageNames[index+'']}
+                            </div>
+                        )
+                    })}
                 </div>
 
-                {/* Schedule Columns: 3개 고정 */}
-                <div className={gridStyles.scheduleArea} style={{ height: `${totalHeightPixels}px` }}>
-                    
-                    {/* Stage 1 */}
-                    <div className={gridStyles.scheduleColumn}>
-                        {stage1Schedules.map((schedule) => (
-                            <ScheduleBlock
-                                key={schedule.start + schedule.artist}
-                                schedule={schedule}
-                                startTimeMinutes={startTimeMinutes}
-                                mode={mode}
-                            />
-                        ))}
-                    </div>
-
-                    {/* Stage 2 */}
-                    <div className={gridStyles.scheduleColumn}>
-                        {stage2Schedules.map((schedule) => (
-                            <ScheduleBlock
-                                key={schedule.start + schedule.artist}
-                                schedule={schedule}
-                                startTimeMinutes={startTimeMinutes}
-                                mode={mode}
-                            />
-                        ))}
-                    </div>
-                    
-                    {/* Stage 3 */}
-                    <div className={gridStyles.scheduleColumn}>
-                        {stage3Schedules.map((schedule) => (
-                            <ScheduleBlock
-                                key={schedule.start + schedule.artist}
-                                schedule={schedule}
-                                startTimeMinutes={startTimeMinutes}
-                                mode={mode}
-                            />
-                        ))}
-                    </div>
+                {/* Schedule Columns */}
+                <div className={gridStyles.scheduleArea} style={{ height:`${totalHeightPixels}px`, width:`${stageKeys.length*STAGE_WIDTH}px` }}>
+                    {stageKeys.map((key,index)=>(
+                        <div key={index} className={gridStyles.scheduleColumn} style={{width:`${STAGE_WIDTH}px`}}>
+                            {stageMap[key].map(schedule=>(
+                                <ScheduleBlock key={schedule.start+schedule.artist} schedule={schedule} startTimeMinutes={startTimeMinutes} mode={mode}/>
+                            ))}
+                        </div>
+                    ))}
                 </div>
             </div>
         </div>

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -71,8 +71,8 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({
                             default: colorClass = gridStyles.colorStage1;
                         }
                         return (
-                            <div key={key} className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
-                                {key} {/* ⭐️ LAND STAGE 대신 실제 Stage Key(Name) 사용을 권장합니다. ⭐️ */}
+                            <div className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
+                                LAND STAGE
                             </div>
                         )
                     })}

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -8,7 +8,8 @@ import gridStyles from '../../css/components/timetable/timetablegrid.module.css'
 
 interface TimetableGridProps {
     stageMap: Record<string, ScheduleItem[]>; 
-    stageNames: Record<string, string>;
+    // ⭐️ REQUIRED: stageNames Prop을 제거하여 타입 오류를 해결합니다. ⭐️
+    // stageNames: Record<string, string>; 
     allSchedules: ScheduleItem[];
     mode: 'customize' | 'my' | 'view';
 }
@@ -20,7 +21,8 @@ const STAGE_WIDTH = 152.5;
 const timeToMinutes = (time: string) => { const [h,m] = time.split(':').map(Number); return h*60+m; };
 const getStartTimeMinutes = (schedules: ScheduleItem[]) => schedules.length===0?900:Math.floor(Math.min(...schedules.map(s=>timeToMinutes(s.start)))/15)*15;
 
-const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, stageNames, allSchedules, mode }) => {
+// ⭐️ Prop 목록에서 stageNames를 제거했습니다. ⭐️
+const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, allSchedules, mode }) => {
     const startTimeMinutes = useMemo(() => getStartTimeMinutes(allSchedules), [allSchedules]);
     const endTimeMinutes = useMemo(() => {
         if(allSchedules.length===0) return startTimeMinutes+120;
@@ -31,6 +33,7 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, stageNames, all
     const totalHeightPixels = ((endTimeMinutes-startTimeMinutes)/TIME_UNIT_MINUTES)*PIXEL_PER_UNIT;
 
     const stageKeys = Object.keys(stageMap);
+    const totalStageCount = stageKeys.length;
 
     return (
         <div className={gridStyles.timetableContainer}>
@@ -38,10 +41,13 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, stageNames, all
 
             <div className={gridStyles.stageGridWrapper} style={{ overflowX: 'auto', width: `calc(100% + 40px)`, marginLeft: '-20px' }}>
                 {/* Stage Header */}
-                <div className={gridStyles.stageHeader} style={{ width: `${stageKeys.length*STAGE_WIDTH}px` }}>
+                <div className={gridStyles.stageHeader} style={{ width: `${totalStageCount * STAGE_WIDTH}px` }}>
                     {stageKeys.map((key,index)=>{
+                        // ⭐️ 색상 순환 로직 개선: 1, 2, 3, 4 이후 다시 1로 돌아가게 합니다. ⭐️
+                        const colorIndex = (index % 4) + 1;
                         let colorClass = '';
-                        switch(index+1){
+                        
+                        switch(colorIndex){
                             case 1: colorClass = gridStyles.colorStage1; break;
                             case 2: colorClass = gridStyles.colorStage2; break;
                             case 3: colorClass = gridStyles.colorStage3; break;
@@ -50,14 +56,15 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, stageNames, all
                         }
                         return (
                             <div key={key} className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
-                               LAND STAGE
+                                {/* ⭐️ Stage 이름 동적 표시: 하드코딩된 'LAND STAGE' 대신 실제 이름(key) 사용 ⭐️ */}
+                                {key}
                             </div>
                         )
                     })}
                 </div>
 
                 {/* Schedule Columns */}
-                <div className={gridStyles.scheduleArea} style={{ height:`${totalHeightPixels}px`, width:`${stageKeys.length*STAGE_WIDTH}px` }}>
+                <div className={gridStyles.scheduleArea} style={{ height:`${totalHeightPixels}px`, width:`${totalStageCount*STAGE_WIDTH}px` }}>
                     {stageKeys.map((key,index)=>(
                         <div key={index} className={gridStyles.scheduleColumn} style={{width:`${STAGE_WIDTH}px`}}>
                             {stageMap[key].map(schedule=>(

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -50,7 +50,7 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, stageNames, all
                         }
                         return (
                             <div key={key} className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
-                                {stageNames[index+'']}
+                               LAND STAGE
                             </div>
                         )
                     })}

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -12,6 +12,7 @@ interface TimetableGridProps {
     // stageNames: Record<string, string>; 
     allSchedules: ScheduleItem[];
     mode: 'customize' | 'my' | 'view';
+    
 }
 
 const TIME_UNIT_MINUTES = 10; 
@@ -56,8 +57,7 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({ stageMap, allSchedules, m
                         }
                         return (
                             <div key={key} className={`${gridStyles.stageHeaderBlock} ${colorClass}`} style={{width:`${STAGE_WIDTH}px`}}>
-                                {/* ⭐️ Stage 이름 동적 표시: 하드코딩된 'LAND STAGE' 대신 실제 이름(key) 사용 ⭐️ */}
-                                {key}
+                                LAND STAGE
                             </div>
                         )
                     })}

--- a/src/components/timetable/TimetableGrid.tsx
+++ b/src/components/timetable/TimetableGrid.tsx
@@ -1,5 +1,3 @@
-// src/components/timetable/TimetableGrid.tsx (Stage 색상 매핑 + 동적 Stage + 횡스크롤)
-
 import React, { useMemo } from 'react';
 import ScheduleBlock from './ScheduleBlock';
 import TimeAxis from './TimeAxis';
@@ -8,12 +6,8 @@ import gridStyles from '../../css/components/timetable/timetablegrid.module.css'
 
 interface TimetableGridProps {
     stageMap: Record<string, ScheduleItem[]>; 
-    // ⭐️ REQUIRED: stageNames Prop을 제거하여 타입 오류를 해결합니다. ⭐️
-    // stageNames: Record<string, string>; 
     allSchedules: ScheduleItem[];
     mode: 'customize' | 'my' | 'view';
-    
-    // ⭐️ (추가) ⭐️ 토글 처리 함수와 활성화된 키 목록을 받습니다.
     onScheduleToggle: (schedule: ScheduleItem) => void;
     activeScheduleKeys: Set<string>; 
 }
@@ -25,12 +19,10 @@ const STAGE_WIDTH = 152.5;
 const timeToMinutes = (time: string) => { const [h,m] = time.split(':').map(Number); return h*60+m; };
 const getStartTimeMinutes = (schedules: ScheduleItem[]) => schedules.length===0?900:Math.floor(Math.min(...schedules.map(s=>timeToMinutes(s.start)))/15)*15;
 
-// ⭐️ Prop 목록에서 stageNames를 제거했습니다. ⭐️
 const TimetableGrid: React.FC<TimetableGridProps> = ({ 
     stageMap, 
     allSchedules, 
     mode, 
-    // ⭐️ (추가) ⭐️ 새로 받은 props를 구조 분해 할당
     onScheduleToggle, 
     activeScheduleKeys 
 }) => {
@@ -46,8 +38,6 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({
     const stageKeys = Object.keys(stageMap);
     const totalStageCount = stageKeys.length;
 
-    // ⭐️ (추가) ⭐️ ScheduleItem의 고유 키를 생성하는 헬퍼 함수
-    // TimetableDetailPage와 동일하게 정의되어야 합니다.
     const createScheduleKey = (s: ScheduleItem) => `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
 
 
@@ -56,10 +46,8 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({
             <TimeAxis startTimeMinutes={startTimeMinutes} endTimeMinutes={endTimeMinutes} totalHeightPixels={totalHeightPixels}/>
 
             <div className={gridStyles.stageGridWrapper} style={{ overflowX: 'auto', width: `calc(100% + 40px)`, marginLeft: '-20px' }}>
-                {/* Stage Header */}
                 <div className={gridStyles.stageHeader} style={{ width: `${totalStageCount * STAGE_WIDTH}px` }}>
-                    {stageKeys.map((key,index)=>{
-                        // ⭐️ 색상 순환 로직 개선: 1, 2, 3, 4 이후 다시 1로 돌아가게 합니다. ⭐️
+                    {stageKeys.map((_key,index)=>{
                         const colorIndex = (index % 4) + 1;
                         let colorClass = '';
                         
@@ -78,22 +66,19 @@ const TimetableGrid: React.FC<TimetableGridProps> = ({
                     })}
                 </div>
 
-                {/* Schedule Columns */}
                 <div className={gridStyles.scheduleArea} style={{ height:`${totalHeightPixels}px`, width:`${totalStageCount*STAGE_WIDTH}px` }}>
                     {stageKeys.map((key,index)=>(
                         <div key={index} className={gridStyles.scheduleColumn} style={{width:`${STAGE_WIDTH}px`}}>
-                            {stageMap[key].map(schedule=>{ // ⭐️ (수정) ⭐️ 중괄호를 사용하여 로직 추가
-                                // ⭐️ (추가) ⭐️ ScheduleBlock에 전달할 isActive 상태 결정
+                            {stageMap[key].map(schedule=>{
                                 const scheduleKey = createScheduleKey(schedule); 
                                 const isActive = activeScheduleKeys.has(scheduleKey);
 
                                 return (
                                     <ScheduleBlock 
-                                        key={scheduleKey} // ⭐️ (수정) ⭐️ 고유 키 사용
+                                        key={scheduleKey} 
                                         schedule={schedule} 
                                         startTimeMinutes={startTimeMinutes} 
                                         mode={mode}
-                                        // ⭐️ (추가) ⭐️ isActive 상태와 토글 함수 전달
                                         isActive={isActive} 
                                         onToggle={onScheduleToggle}
                                     />

--- a/src/css/components/timetable/festivallistitem.module.css
+++ b/src/css/components/timetable/festivallistitem.module.css
@@ -61,6 +61,13 @@
   letter-spacing: -0.3px;
 }
 
+.location{
+  max-width: 80px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .arrowIcon {
   width: 20px;
   height: 20px;

--- a/src/css/components/timetable/recommendcard.module.css
+++ b/src/css/components/timetable/recommendcard.module.css
@@ -11,11 +11,9 @@
   justify-content: center;
   align-items: center;
   aspect-ratio: 3/4;
-  width:132px;
-  height:176px;
+  width: 132px;
+  height: 176px;
 }
-
-
 
 .cardInfo {
   margin-bottom: 8px;
@@ -32,7 +30,7 @@
   width: 132px;
   margin: 0;
   align-self: stretch;
-  margin-bottom:3px;
+  margin-bottom: 3px;
 }
 
 .cardDate {
@@ -48,7 +46,7 @@
 }
 
 .customButton {
-  cursor:pointer;
+  cursor: pointer;
   display: flex;
   width: 132px;
   padding: 8px 0;

--- a/src/css/components/timetable/recommendcard.module.css
+++ b/src/css/components/timetable/recommendcard.module.css
@@ -11,6 +11,8 @@
   justify-content: center;
   align-items: center;
   aspect-ratio: 3/4;
+  width:132px;
+  height:176px;
 }
 
 

--- a/src/css/components/timetable/scheduleblock.module.css
+++ b/src/css/components/timetable/scheduleblock.module.css
@@ -87,3 +87,8 @@ box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 /* time_block_shadow */
 box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
+
+.colorStage5 {
+    background: var(--b-1, rgba(251, 188, 5, 0.20));
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+}

--- a/src/css/components/timetable/scheduleblock.module.css
+++ b/src/css/components/timetable/scheduleblock.module.css
@@ -1,14 +1,10 @@
-/* src/css/components/timetable/scheduleblock.module.css */
-
 .scheduleBlock {
     position: absolute; 
     width: 100%;
     padding: 8px;
     box-sizing: border-box;
-  
     cursor: pointer;
     z-index: 3; 
-    
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -16,10 +12,9 @@
     text-align: center;
     overflow: hidden;
     transition: background-color 0.2s, box-shadow 0.2s;
-    
     color: var(--g-100, #1a1a1a);
     font-family: Inter;
-    background: var(--g-30, #EBEBEB); /* 초기 상태 회색 */
+    background: var(--g-30, #EBEBEB);
 }
 
 .scheduleBlock:hover {
@@ -34,58 +29,46 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     max-width:120px;
-
 }
 
 .time {
     color: var(--g-100, #1A1A1A);
-
-/* light/10 */
-font-family: Inter;
-font-size: 10px;
-font-style: normal;
-font-weight: 300;
-line-height: normal;
-letter-spacing: -0.3px;
+    font-family: Inter;
+    font-size: 10px;
+    font-style: normal;
+    font-weight: 300;
+    line-height: normal;
+    letter-spacing: -0.3px;
 }
 
 .duration {
     color: var(--g-100, #1A1A1A);
-
-/* light/10 */
-font-family: Inter;
-font-size: 10px;
-font-style: normal;
-font-weight: 300;
-line-height: normal;
-letter-spacing: -0.3px;
+    font-family: Inter;
+    font-size: 10px;
+    font-style: normal;
+    font-weight: 300;
+    line-height: normal;
+    letter-spacing: -0.3px;
 }
 
-/* Stage별 색상 클래스 */
 .colorStage1 {
     background: var(--b-1, rgba(251, 188, 5, 0.20));
-box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
 
 .colorStage2 {
    background: var(--b-2, rgba(198, 108, 217, 0.20));
-
-/* time_block_shadow */
-box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+   box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
 
 .colorStage3 {
     background: var(--b-3, rgba(52, 168, 83, 0.20));
-
-/* time_block_shadow */
-box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
 
 .colorStage4 {
     background: var(--b-4, rgba(66, 133, 244, 0.20));
-
-/* time_block_shadow */
-box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
 
 .colorStage5 {

--- a/src/css/components/timetable/scheduleblock.module.css
+++ b/src/css/components/timetable/scheduleblock.module.css
@@ -5,7 +5,7 @@
     width: 100%;
     padding: 8px;
     box-sizing: border-box;
-    border-radius: 6px;
+  
     cursor: pointer;
     z-index: 3; 
     
@@ -19,10 +19,11 @@
     
     color: var(--g-100, #1a1a1a);
     font-family: Inter;
+    background: var(--g-30, #EBEBEB); /* 초기 상태 회색 */
 }
 
 .scheduleBlock:hover {
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+   box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
 
 .artist {
@@ -35,26 +36,52 @@
 }
 
 .time {
-    font-size: 10px;
-    font-weight: 400;
-    line-height: 1.4;
-    color: var(--g-80, #555);
+    color: var(--g-100, #1A1A1A);
+
+/* light/10 */
+font-family: Inter;
+font-size: 10px;
+font-style: normal;
+font-weight: 300;
+line-height: normal;
+letter-spacing: -0.3px;
 }
 
 .duration {
-    font-size: 10px;
-    font-weight: 400;
-    line-height: 1.4;
-    color: var(--g-60, #8F8F8F);
+    color: var(--g-100, #1A1A1A);
+
+/* light/10 */
+font-family: Inter;
+font-size: 10px;
+font-style: normal;
+font-weight: 300;
+line-height: normal;
+letter-spacing: -0.3px;
 }
 
-/* ⭐️ 색상 클래스 (스크린샷 기반) ⭐️ */
-.colorYellow {
-    background-color: #FFFCE0; 
-    border: 1px solid #FFE0B2; 
+/* Stage별 색상 클래스 */
+.colorStage1 {
+    background: var(--b-1, rgba(251, 188, 5, 0.20));
+box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }
 
-.colorPurple {
-    background-color: #F7E4FF; 
-    border: 1px solid #E1BEE7; 
+.colorStage2 {
+   background: var(--b-2, rgba(198, 108, 217, 0.20));
+
+/* time_block_shadow */
+box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+}
+
+.colorStage3 {
+    background: var(--b-3, rgba(52, 168, 83, 0.20));
+
+/* time_block_shadow */
+box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
+}
+
+.colorStage4 {
+    background: var(--b-4, rgba(66, 133, 244, 0.20));
+
+/* time_block_shadow */
+box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.25);
 }

--- a/src/css/components/timetable/scheduleblock.module.css
+++ b/src/css/components/timetable/scheduleblock.module.css
@@ -1,0 +1,60 @@
+/* src/css/components/timetable/scheduleblock.module.css */
+
+.scheduleBlock {
+    position: absolute; 
+    width: 100%;
+    padding: 8px;
+    box-sizing: border-box;
+    border-radius: 6px;
+    cursor: pointer;
+    z-index: 3; 
+    
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    overflow: hidden;
+    transition: background-color 0.2s, box-shadow 0.2s;
+    
+    color: var(--g-100, #1a1a1a);
+    font-family: Inter;
+}
+
+.scheduleBlock:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.artist {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.2;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.time {
+    font-size: 10px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: var(--g-80, #555);
+}
+
+.duration {
+    font-size: 10px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: var(--g-60, #8F8F8F);
+}
+
+/* ⭐️ 색상 클래스 (스크린샷 기반) ⭐️ */
+.colorYellow {
+    background-color: #FFFCE0; 
+    border: 1px solid #FFE0B2; 
+}
+
+.colorPurple {
+    background-color: #F7E4FF; 
+    border: 1px solid #E1BEE7; 
+}

--- a/src/css/components/timetable/scheduleblock.module.css
+++ b/src/css/components/timetable/scheduleblock.module.css
@@ -33,6 +33,8 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    max-width:120px;
+
 }
 
 .time {

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -9,6 +9,7 @@
     width: 100vw;
 	position: relative;
 	left: calc(-50vw +50%); 
+    
 }
 
 /* ================== 시간 축 (TimeAxis) ================== */
@@ -39,6 +40,7 @@
     display: flex;
     flex-direction: column;
     padding-left:20px;
+     scrollbar-width: none; /* Firefox */
 }
 
 
@@ -86,6 +88,7 @@
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 10px; /* optional */
+  scrollbar-width: none; /* Firefox */
 }
 
 .timetableScrollWrapper {

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -1,0 +1,91 @@
+/* src/css/components/timetable/timetablegrid.module.css (Stage 3개 고정 버전) */
+
+.timetableContainer {
+    display: flex;
+    overflow-y: auto; 
+    max-height: 50vh; 
+    margin-top: 16px;
+    padding-bottom: 20px;
+    width: 100%;
+    position: relative; 
+}
+
+/* ================== 시간 축 (TimeAxis) ================== */
+.timeAxis {
+    width: 40px; 
+    position: relative;
+    flex-shrink: 0;
+    z-index: 2; 
+    padding-top: 15px; 
+}
+
+.timeLabel {
+    position: absolute;
+    transform: translateY(-50%);
+    font-size: 10px;
+    color: var(--g-80, #555);
+    right: 5px; 
+    font-weight: 500;
+}
+
+/* 횡스크롤 이전 버전에서는 TimeAxis에서 렌더링된 요소가 StageGridWrapper 영역까지 침범하도록 설정 */
+.timeDivider {
+    position: absolute;
+    width: 100vw; /* StageGridWrapper를 가로질러 확장 */
+    height: 1px;
+    border-top: 1px dashed var(--g-40, #D1D1D1);
+    transform: translateY(-50%);
+    left: 40px; /* TimeAxis 너비만큼 이동 */
+    z-index: 1;
+}
+
+
+/* ================== 스테이지 그리드 ================== */
+.stageGridWrapper {
+    flex-grow: 1; 
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden; /* 횡스크롤 제거 */
+}
+
+
+/* Stage Header (StageName) */
+.stageHeader {
+    display: flex;
+    width: 100%;
+    margin-bottom: 5px;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    padding-top: 15px;
+}
+
+.stageHeaderBlock {
+    flex: 1; /* 3개 스테이지가 화면 너비에 맞춰 균등 분할 */
+    min-width: 100px; /* 최소 너비 지정 */
+    
+    height: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 12px;
+    font-weight: 500;
+    color: white;
+    background-color: var(--p-40, #8D4E99);
+    border-radius: 4px;
+    margin: 0 4px; 
+}
+
+/* 일정 블록 영역 */
+.scheduleArea {
+    display: flex;
+    width: 100%; 
+    position: relative; 
+}
+
+.scheduleColumn {
+    flex: 1; /* Stage Header와 동일하게 균등 분할 */
+    min-width: 100px; 
+    position: relative;
+    margin: 0 4px; 
+}

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -39,7 +39,7 @@
     flex-grow: 1; 
     display: flex;
     z-index:5;
-    max-width:545px;
+     max-width :545px;
     flex-direction: column;
     padding-left:20px;
      scrollbar-width: none; /* Firefox */
@@ -48,7 +48,7 @@
 /* ⭐ Viewport 375px 이하에서 max-width를 330px로 조정 ⭐ */
 @media (max-width: 375px) {
     .stageGridWrapper {
-        max-width: 315px;
+        max-width: 320px;
     }
 }
 

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -1,5 +1,3 @@
-/* src/css/components/timetable/timetablegrid.module.css (Stage 3개 고정 버전) */
-
 .timetableContainer {
     display: flex;
     overflow-y: auto; 
@@ -9,17 +7,14 @@
     width: 100vw;
 	position: relative;
 	left: calc(-50vw +50%); 
-    
 }
 
-/* ================== 시간 축 (TimeAxis) ================== */
 .timeAxis {
     margin-top:62px;
     width:35px; 
     position: relative;
     flex-shrink: 0;
     z-index: 100; 
-
 }
 
 .timeLabel {
@@ -31,116 +26,91 @@
     padding-right:4px;
 }
 
-
-
-
-/* ================== 스테이지 그리드 ================== */
 .stageGridWrapper {
     flex-grow: 1; 
     display: flex;
     z-index:5;
-     max-width :545px;
+    max-width:545px;
     flex-direction: column;
     padding-left:20px;
-     scrollbar-width: none; /* Firefox */
+    scrollbar-width: none;
 }
 
-/* ⭐ Viewport 375px 이하에서 max-width를 330px로 조정 ⭐ */
 @media (max-width: 375px) {
     .stageGridWrapper {
         max-width: 320px;
     }
 }
 
-
-/* Stage Header (StageName) */
 .stageHeader {
-    
     display: flex;
     width: 100%;
     margin-bottom: 5px;
     position: sticky;
     top: 0;
-    
     margin-bottom: 33px;
-   
 }
 
 .stageHeaderBlock {
-    
     height: 24px;
-    
     display: flex;
     justify-content: center;
     align-items: center;
     font-size: 12px;
     font-weight: 500;
     color: black;
-
 }
 
-/* 일정 블록 영역 */
 .scheduleArea {
     display: flex;
     width: calc(100% + 40px);
     position: relative; 
-    
 }
 
 .scheduleColumn {
-    flex: 1; /* Stage Header와 동일하게 균등 분할 */
-    
+    flex: 1;
     position: relative;
-    
 }
+
 .timetableScrollWrapper {
-
-
   overflow-x: auto;
   overflow-y: hidden;
-  padding-bottom: 10px; /* optional */
-  scrollbar-width: none; /* Firefox */
-  
+  padding-bottom: 10px;
+  scrollbar-width: none;
 }
-
-
 
 .scheduleArea {
   display: flex;
   position: relative;
-  width: auto; /* 원래대로 */
+  width: auto;
 }
-/* Stage Header 색상 매핑 */
+
 .colorStage1 {
     border-top: 1px solid var(--g-100, #1A1A1A);
-border-bottom: 1px solid var(--g-100, #1A1A1A);
-background: var(--b-1, rgba(251, 188, 5, 0.20));
+    border-bottom: 1px solid var(--g-100, #1A1A1A);
+    background: var(--b-1, rgba(251, 188, 5, 0.20));
 }
 
 .colorStage2 {
-border-top: 1px solid var(--g-100, #1A1A1A);
-border-bottom: 1px solid var(--g-100, #1A1A1A);
-background: var(--b-2, rgba(198, 108, 217, 0.20));
-   
+    border-top: 1px solid var(--g-100, #1A1A1A);
+    border-bottom: 1px solid var(--g-100, #1A1A1A);
+    background: var(--b-2, rgba(198, 108, 217, 0.20));
 }
 
 .colorStage3 {
     border-top: 1px solid var(--g-100, #1A1A1A);
-border-bottom: 1px solid var(--g-100, #1A1A1A);
-background: var(--b-3, rgba(52, 168, 83, 0.20));
+    border-bottom: 1px solid var(--g-100, #1A1A1A);
+    background: var(--b-3, rgba(52, 168, 83, 0.20));
 }
 
 .colorStage4 {
-   border-top: 1px solid var(--g-100, #1A1A1A);
-border-bottom: 1px solid var(--g-100, #1A1A1A);
-background: var(--b-4, rgba(66, 133, 244, 0.20));
+    border-top: 1px solid var(--g-100, #1A1A1A);
+    border-bottom: 1px solid var(--g-100, #1A1A1A);
+    background: var(--b-4, rgba(66, 133, 244, 0.20));
 }
 
-/* ... 기존 색상 정의 (colorStage1 ~ colorStage4) ... */
-
-/* ⭐️ 5개 스테이지일 때 적용할 노란색 스타일 정의 ⭐️ */
 .colorStage5 {
-     border-top: 1px solid var(--g-100, #1A1A1A);
-border-bottom: 1px solid var(--g-100, #1A1A1A);
-background: var(--b-1, rgba(251, 188, 5, 0.20));
+    border-top: 1px solid var(--g-100, #1A1A1A);
+    border-bottom: 1px solid var(--g-100, #1A1A1A);
+    background: var(--b-1, rgba(251, 188, 5, 0.20));
 }

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -38,7 +38,7 @@
 
 @media (max-width: 375px) {
     .stageGridWrapper {
-        max-width: 320px;
+        max-width: 300px;
     }
 }
 

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -3,7 +3,7 @@
 .timetableContainer {
     display: flex;
     overflow-y: auto; 
-    max-height: 50vh; 
+   
     margin-top: 16px;
     padding-bottom: 20px;
     width: 100%;
@@ -12,11 +12,11 @@
 
 /* ================== 시간 축 (TimeAxis) ================== */
 .timeAxis {
+    margin-top:50px;
     width: 40px; 
     position: relative;
     flex-shrink: 0;
     z-index: 2; 
-    padding-top: 15px; 
 }
 
 .timeLabel {

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -26,7 +26,6 @@
     transform: translateY(-50%);
     font-size: 10px;
     color: var(--g-80, #555);
-    
     font-weight: 500;
     padding-right:8px;
 }
@@ -38,6 +37,8 @@
 .stageGridWrapper {
     flex-grow: 1; 
     display: flex;
+    
+    
     flex-direction: column;
     padding-left:20px;
      scrollbar-width: none; /* Firefox */
@@ -46,6 +47,7 @@
 
 /* Stage Header (StageName) */
 .stageHeader {
+    
     display: flex;
     width: 100%;
     margin-bottom: 5px;
@@ -57,7 +59,7 @@
 }
 
 .stageHeaderBlock {
-    min-width: 100px; /* 최소 너비 지정 */
+    
     height: 24px;
     display: flex;
     justify-content: center;
@@ -78,12 +80,12 @@
 
 .scheduleColumn {
     flex: 1; /* Stage Header와 동일하게 균등 분할 */
-    min-width: 100px; 
+    
     position: relative;
     
 }
 .timetableScrollWrapper {
-  width: calc(100% + 40px);
+
   margin-left: -20px;
   overflow-x: auto;
   overflow-y: hidden;
@@ -92,7 +94,7 @@
 }
 
 .timetableScrollWrapper {
-  width: calc(100% + 40px);
+  
   margin-left: -20px;
   overflow-x: auto;
   overflow-y: hidden;

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -15,10 +15,11 @@
 /* ================== 시간 축 (TimeAxis) ================== */
 .timeAxis {
     margin-top:62px;
-    width: 40px; 
+    width:35px; 
     position: relative;
     flex-shrink: 0;
-    z-index: 2; 
+    z-index: 100; 
+
 }
 
 .timeLabel {
@@ -27,7 +28,7 @@
     font-size: 10px;
     color: var(--g-80, #555);
     font-weight: 500;
-    padding-right:8px;
+    padding-right:4px;
 }
 
 
@@ -37,11 +38,18 @@
 .stageGridWrapper {
     flex-grow: 1; 
     display: flex;
-    
-    
+    z-index:5;
+    max-width:545px;
     flex-direction: column;
     padding-left:20px;
      scrollbar-width: none; /* Firefox */
+}
+
+/* ⭐ Viewport 375px 이하에서 max-width를 330px로 조정 ⭐ */
+@media (max-width: 375px) {
+    .stageGridWrapper {
+        max-width: 315px;
+    }
 }
 
 
@@ -53,7 +61,7 @@
     margin-bottom: 5px;
     position: sticky;
     top: 0;
-    z-index: 5;
+    
     margin-bottom: 33px;
    
 }
@@ -61,6 +69,7 @@
 .stageHeaderBlock {
     
     height: 24px;
+    
     display: flex;
     justify-content: center;
     align-items: center;
@@ -86,20 +95,15 @@
 }
 .timetableScrollWrapper {
 
-  margin-left: -20px;
+
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 10px; /* optional */
   scrollbar-width: none; /* Firefox */
+  
 }
 
-.timetableScrollWrapper {
-  
-  margin-left: -20px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding-bottom: 10px; /* optional */
-}
+
 
 .scheduleArea {
   display: flex;
@@ -130,4 +134,13 @@ background: var(--b-3, rgba(52, 168, 83, 0.20));
    border-top: 1px solid var(--g-100, #1A1A1A);
 border-bottom: 1px solid var(--g-100, #1A1A1A);
 background: var(--b-4, rgba(66, 133, 244, 0.20));
+}
+
+/* ... 기존 색상 정의 (colorStage1 ~ colorStage4) ... */
+
+/* ⭐️ 5개 스테이지일 때 적용할 노란색 스타일 정의 ⭐️ */
+.colorStage5 {
+     border-top: 1px solid var(--g-100, #1A1A1A);
+border-bottom: 1px solid var(--g-100, #1A1A1A);
+background: var(--b-1, rgba(251, 188, 5, 0.20));
 }

--- a/src/css/components/timetable/timetablegrid.module.css
+++ b/src/css/components/timetable/timetablegrid.module.css
@@ -3,16 +3,17 @@
 .timetableContainer {
     display: flex;
     overflow-y: auto; 
-   
-    margin-top: 16px;
     padding-bottom: 20px;
     width: 100%;
     position: relative; 
+    width: 100vw;
+	position: relative;
+	left: calc(-50vw +50%); 
 }
 
 /* ================== 시간 축 (TimeAxis) ================== */
 .timeAxis {
-    margin-top:50px;
+    margin-top:62px;
     width: 40px; 
     position: relative;
     flex-shrink: 0;
@@ -24,20 +25,12 @@
     transform: translateY(-50%);
     font-size: 10px;
     color: var(--g-80, #555);
-    right: 5px; 
+    
     font-weight: 500;
+    padding-right:8px;
 }
 
-/* 횡스크롤 이전 버전에서는 TimeAxis에서 렌더링된 요소가 StageGridWrapper 영역까지 침범하도록 설정 */
-.timeDivider {
-    position: absolute;
-    width: 100vw; /* StageGridWrapper를 가로질러 확장 */
-    height: 1px;
-    border-top: 1px dashed var(--g-40, #D1D1D1);
-    transform: translateY(-50%);
-    left: 40px; /* TimeAxis 너비만큼 이동 */
-    z-index: 1;
-}
+
 
 
 /* ================== 스테이지 그리드 ================== */
@@ -45,7 +38,7 @@
     flex-grow: 1; 
     display: flex;
     flex-direction: column;
-    overflow-x: hidden; /* 횡스크롤 제거 */
+    padding-left:20px;
 }
 
 
@@ -57,35 +50,79 @@
     position: sticky;
     top: 0;
     z-index: 5;
-    padding-top: 15px;
+    margin-bottom: 33px;
+   
 }
 
 .stageHeaderBlock {
-    flex: 1; /* 3개 스테이지가 화면 너비에 맞춰 균등 분할 */
     min-width: 100px; /* 최소 너비 지정 */
-    
-    height: 30px;
+    height: 24px;
     display: flex;
     justify-content: center;
     align-items: center;
     font-size: 12px;
     font-weight: 500;
-    color: white;
-    background-color: var(--p-40, #8D4E99);
-    border-radius: 4px;
-    margin: 0 4px; 
+    color: black;
+
 }
 
 /* 일정 블록 영역 */
 .scheduleArea {
     display: flex;
-    width: 100%; 
+    width: calc(100% + 40px);
     position: relative; 
+    
 }
 
 .scheduleColumn {
     flex: 1; /* Stage Header와 동일하게 균등 분할 */
     min-width: 100px; 
     position: relative;
-    margin: 0 4px; 
+    
+}
+.timetableScrollWrapper {
+  width: calc(100% + 40px);
+  margin-left: -20px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 10px; /* optional */
+}
+
+.timetableScrollWrapper {
+  width: calc(100% + 40px);
+  margin-left: -20px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 10px; /* optional */
+}
+
+.scheduleArea {
+  display: flex;
+  position: relative;
+  width: auto; /* 원래대로 */
+}
+/* Stage Header 색상 매핑 */
+.colorStage1 {
+    border-top: 1px solid var(--g-100, #1A1A1A);
+border-bottom: 1px solid var(--g-100, #1A1A1A);
+background: var(--b-1, rgba(251, 188, 5, 0.20));
+}
+
+.colorStage2 {
+border-top: 1px solid var(--g-100, #1A1A1A);
+border-bottom: 1px solid var(--g-100, #1A1A1A);
+background: var(--b-2, rgba(198, 108, 217, 0.20));
+   
+}
+
+.colorStage3 {
+    border-top: 1px solid var(--g-100, #1A1A1A);
+border-bottom: 1px solid var(--g-100, #1A1A1A);
+background: var(--b-3, rgba(52, 168, 83, 0.20));
+}
+
+.colorStage4 {
+   border-top: 1px solid var(--g-100, #1A1A1A);
+border-bottom: 1px solid var(--g-100, #1A1A1A);
+background: var(--b-4, rgba(66, 133, 244, 0.20));
 }

--- a/src/css/pages/concertprofile.module.css
+++ b/src/css/pages/concertprofile.module.css
@@ -187,6 +187,7 @@
   font-weight: 600;
   border: none;
   letter-spacing: -0.3px;
+  cursor:pointer;
 }
 
 
@@ -250,5 +251,6 @@
   border-radius: 4px;
   background-color: transparent; 
   color: #E69BF5;               
-  border: 1px solid #E69BF5;       
+  border: 1px solid #E69BF5; 
+  cursor: pointer;     
 }

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -175,7 +175,7 @@ letter-spacing: -0.36px;
     
     /* ⭐️ 수정: .dropdownWrapper 기준이므로 left: 0px ⭐️ */
     left: 0px; 
-    z-index: 10; 
+    z-index: 300; 
     width: 83px; 
     
     padding: 0; 

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -5,55 +5,45 @@
   flex-direction: column;
 }
 
+/* ========================================================= */
+/* 1. Header 및 제목 스타일 */
+/* ========================================================= */
+
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  /* (사용자 요청 속성 유지) 좌우 패딩이 0이므로, 버튼과 emptyBox에 마진/패딩을 추가하여 여백 확보 */
+  padding: 12px 0px; 
 }
 
-/* ⭐️ .button (또는 .backButton) 초기화 속성 ⭐️ */
+/* 뒤로 가기 버튼 초기화 */
 .backButton {
-  /* 1. 모든 기본 버튼 스타일 제거 (모든 사용자 에이전트 스타일 초기화) */
   all: unset; 
-  
-  /* 2. pointer 이벤트 및 접근성 유지를 위해 필수 속성 재설정 */
   border: none;
   background: none;
   padding: 0;
   cursor: pointer;
-  
-  /* 3. 혹시 모를 내부 이미지의 크기 간섭을 막기 위해 크기 관련 속성 제거 */
-  /* width, height, flex-shrink 등 기존에 정의된 모든 레이아웃 속성을 제거합니다. */
-
-  /* 4. 포커스 시 외곽선 제거 (필요에 따라) */
   outline: none; 
+  /* ⭐️ 추가: Header padding이 0px이므로 좌측 여백 확보 ⭐️ */
+ 
 }
 
-/* ⭐️ 버튼 내부의 이미지 크기는 img 태그에 직접 지정해야 합니다. ⭐️ */
+/* 버튼 내부 이미지 크기 설정 */
 .backButton img {
-    /* 예시: 이미지가 24px 크기를 가지도록 설정 */
     width: 24px; 
     height: 28px;
     flex-shrink: 0;
 }
 
-
+/* 페이지 제목: 중앙 정렬 및 줄임표 처리 */
 .pageTitle {
-  /* ⭐️ 1. 남은 공간을 모두 차지하도록 확장 ⭐️ */
   flex-grow: 1;
-  /* ⭐️ 2. 텍스트를 중앙 정렬하여 backButton과 emptyBox 사이에 위치 ⭐️ */
   text-align: center;
-  
-  /* ⭐️ 3. 줄임표 (...) 처리를 위한 필수 3종 세트 ⭐️ */
-  /* 넘치는 텍스트를 숨김 */
   overflow: hidden; 
-  /* 텍스트를 한 줄로 강제 */
   white-space: nowrap; 
-  /* 넘치는 텍스트를 ...로 표시 */
   text-overflow: ellipsis; 
 
-  /* 기존 폰트 속성 유지 */
   color: var(--g-100, #1a1a1a);
   font-family: Inter;
   font-size: 16px;
@@ -62,26 +52,225 @@
   line-height: normal;
   letter-spacing: -0.48px;
   
-  /* 버튼과의 간섭 방지를 위해 좌우 마진 추가 (선택 사항) */
-  margin: 0 10px; 
 }
+
+/* 제목 오른쪽을 채우는 빈 상자 (레이아웃 균형용) */
 .emptyBox{
-       width: 24px; 
+    width: 24px; 
+    height: 24px;
+    display: block;
+    /* ⭐️ 추가: Header padding이 0px이므로 우측 여백 확보 ⭐️ */
+    
+}
+
+/* ========================================================= */
+/* 2. 타임테이블 컨트롤 바 (드롭다운 + 액션 버튼) */
+/* ========================================================= */
+
+/* ⭐️ 컨트롤 바 전체 컨테이너 (.timetableControlBar) ⭐️ */
+.timetableControlBar {
+    display: flex;
+    justify-content: space-between; /* 드롭다운과 액션 버튼을 양 끝에 배치 */
+    align-items: center;
+    flex-shrink: 0;
+    padding: 16px 0px;
+}
+
+/* ⭐️ 드롭다운 요소만 감싸는 래퍼 (.dropdownWrapper) - List의 absolute 기준점 ⭐️ */
+.dropdownWrapper {
+    position: relative; 
+    display: block; 
+}
+
+/* 토글 버튼 (현재 선택된 날짜 표시 영역) */
+.dayDropdownToggle {
+    all: unset; 
+    
+    box-sizing: border-box;
+    width: 83px; 
+    
+    display: flex;
+    padding: 6px 8px;
+    align-items: center;
+    justify-content: space-between; 
+    gap: 10px;
+    flex-shrink: 0;
+    border-radius: 4px;
+   
+border: 1px solid var(--p-20, #C66CD9);
+background: var(--g-0, #FFF);
+    
+    background: var(--g-0, #FFF);
+    cursor: pointer;
+    
+    transition: border-color 0.2s; 
+    color: var(--p-20, #C66CD9);
+
+/* medium/12 */
+font-family: Inter;
+font-size: 12px;
+font-style: normal;
+font-weight: 500;
+line-height: normal;
+letter-spacing: -0.36px;
+}
+
+/* 토글 버튼 열림 상태 스타일 */
+.dayDropdownToggle.open {
+    border: 1px solid var(--p-20, #C66CD9);
+}
+
+.dayDropdownToggle span {
+    flex-grow: 1; 
+}
+
+/* 선택된 날짜 (보라색 글꼴) */
+.fontSet {
+    color: var(--p-20, #C66CD9); 
+    font-family: Inter;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+    letter-spacing: -0.36px;
+    white-space: nowrap;
+    
+}
+
+/* Placeholder/열림 상태 텍스트 ('날짜 선택') */
+.placeholderText {
+    color: var(--g-40, #D1D1D1);
+
+/* regular/12 */
+font-family: Inter;
+font-size: 12px;
+font-style: normal;
+font-weight: 400;
+line-height: normal;
+letter-spacing: -0.36px;
+    white-space: nowrap;
+    
+}
+
+/* 화살표 아이콘 스타일 */
+.dayDropdownToggle img {
+    width: 16px; 
+    height: 16px;
+    flex-shrink: 0;
+    transition: transform 0.3s ease; 
+}
+
+.arrowClosed {
+    transform: rotate(0deg);
+}
+
+.arrowOpen {
+    transform: rotate(180deg);
+}
+
+
+/* 1. 드롭다운 목록 (ul 태그) */
+.dayDropdownList {
+    position: absolute; 
+    
+    /* ⭐️ 수정: .dropdownWrapper 기준이므로 left: 0px ⭐️ */
+    left: 0px; 
+    z-index: 10; 
+    width: 83px; 
+    
+    padding: 0; 
+    margin: 4px 0 0 0;
+    
+    border: 1px solid var(--p-20, #C66CD9); 
+    border-radius: 4px;
+    background-color: white;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* 2. 목록의 각 항목 (li 태그) */
+.dayDropdownItem {
+    width: 83px;
+    
+ 
+}
+
+/* 3. 목록 내부의 날짜 선택 버튼 (실제 클릭 영역) */
+.dayDropdownOption {
+    all: unset; 
+    display: block;
+    width: 83px;
+    padding: 8px 0px;
+    
+    
+    cursor: pointer;
+    
+    font-family: Inter;
+font-size: 12px;
+font-style: normal;
+font-weight: 500;
+line-height: normal;
+letter-spacing: -0.36px;
+    color: #333; 
+}
+
+/* 4. 마우스 오버(hover) 및 선택(active) 스타일 */
+.dayDropdownOption:hover {
+    background-color: #f7f7f7;
+}
+
+/* 현재 선택된 항목 스타일 */
+.dayDropdownOption.active {
+   background: var(--b-210, rgba(198, 108, 217, 0.10));
+    color: var(--p-20, #C66CD9);
+/* medium/12 */
+font-family: Inter;
+font-size: 12px;
+font-style: normal;
+font-weight: 500;
+line-height: normal;
+letter-spacing: -0.36px;
+padding-left:
+
+}
+
+/* ========================================================= */
+/* 3. 액션 버튼 (다운로드/되돌리기) 스타일 */
+/* ========================================================= */
+
+/* ⭐️ 액션 버튼 래퍼 (.actionButtonWrapper) ⭐️ */
+.actionButtonWrapper {
+    display: flex;
+    gap: 8px; /* 버튼 간격 */
+    flex-shrink: 0;
+}
+
+/* ⭐️ 개별 액션 버튼 (.actionButton) ⭐️ */
+.actionButton {
+    all: unset;
+    cursor: pointer;
+    padding: 4px; 
+    border-radius: 4px;
+    transition: background-color 0.2s;
+    
+    /* Flex item으로 작동하도록 설정 */
+    display: flex; 
+    align-items: center;
+    justify-content: center;
+}
+
+.actionButton:hover {
+    background-color: var(--g-10, #f0f0f0);
+}
+
+/* ⭐️ 액션 버튼 내부 이미지 크기 ⭐️ */
+.actionButton img {
+    width: 24px;
     height: 24px;
     display: block;
 }
 
-
-/* 날짜 선택 드롭다운, 이미지저장, 되돌리기 버튼 */
-
-.dayDropdown{
-    display: flex;
-width: 83px;
-padding: 6px 8px;
-align-items: center;
-gap: 10px;
+.selectedDateTextWrapper {
+   width: 67px;
 flex-shrink: 0;
-border-radius: 4px;
-border: 1px solid var(--p-20, #C66CD9);
-background: var(--g-0, #FFF);
+margin-left:8px;
 }

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -1,0 +1,72 @@
+/* src/css/pages/timetable/timetabledetail.module.css */
+
+.pageContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+/* ⭐️ .button (또는 .backButton) 초기화 속성 ⭐️ */
+.backButton {
+  /* 1. 모든 기본 버튼 스타일 제거 (모든 사용자 에이전트 스타일 초기화) */
+  all: unset; 
+  
+  /* 2. pointer 이벤트 및 접근성 유지를 위해 필수 속성 재설정 */
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  
+  /* 3. 혹시 모를 내부 이미지의 크기 간섭을 막기 위해 크기 관련 속성 제거 */
+  /* width, height, flex-shrink 등 기존에 정의된 모든 레이아웃 속성을 제거합니다. */
+
+  /* 4. 포커스 시 외곽선 제거 (필요에 따라) */
+  outline: none; 
+}
+
+/* ⭐️ 버튼 내부의 이미지 크기는 img 태그에 직접 지정해야 합니다. ⭐️ */
+.backButton img {
+    /* 예시: 이미지가 24px 크기를 가지도록 설정 */
+    width: 24px; 
+    height: 28px;
+    flex-shrink: 0;
+}
+
+
+.pageTitle {
+  /* ⭐️ 1. 남은 공간을 모두 차지하도록 확장 ⭐️ */
+  flex-grow: 1;
+  /* ⭐️ 2. 텍스트를 중앙 정렬하여 backButton과 emptyBox 사이에 위치 ⭐️ */
+  text-align: center;
+  
+  /* ⭐️ 3. 줄임표 (...) 처리를 위한 필수 3종 세트 ⭐️ */
+  /* 넘치는 텍스트를 숨김 */
+  overflow: hidden; 
+  /* 텍스트를 한 줄로 강제 */
+  white-space: nowrap; 
+  /* 넘치는 텍스트를 ...로 표시 */
+  text-overflow: ellipsis; 
+
+  /* 기존 폰트 속성 유지 */
+  color: var(--g-100, #1a1a1a);
+  font-family: Inter;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  letter-spacing: -0.48px;
+  
+  /* 버튼과의 간섭 방지를 위해 좌우 마진 추가 (선택 사항) */
+  margin: 0 10px; 
+}
+.emptyBox{
+       width: 24px; 
+    height: 24px;
+    display: block;
+}

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -134,7 +134,6 @@ letter-spacing: -0.36px;
     line-height: normal;
     letter-spacing: -0.36px;
     white-space: nowrap;
-    
 }
 
 /* Placeholder/열림 상태 텍스트 ('날짜 선택') */

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -189,8 +189,7 @@ letter-spacing: -0.36px;
 /* 2. 목록의 각 항목 (li 태그) */
 .dayDropdownItem {
     width: 83px;
-    
- 
+
 }
 
 /* 3. 목록 내부의 날짜 선택 버튼 (실제 클릭 영역) */
@@ -211,6 +210,10 @@ line-height: normal;
 letter-spacing: -0.36px;
     color: #333; 
 }
+.textSpace 
+{
+    padding-left:8px;
+}
 
 /* 4. 마우스 오버(hover) 및 선택(active) 스타일 */
 .dayDropdownOption:hover {
@@ -228,7 +231,7 @@ font-style: normal;
 font-weight: 500;
 line-height: normal;
 letter-spacing: -0.36px;
-padding-left:
+
 
 }
 

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -177,16 +177,12 @@
     all: unset;
     cursor: pointer;
     padding: 4px;
-    border-radius: 4px;
-    transition: background-color 0.2s;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.actionButton:hover {
-    background-color: var(--g-10, #f0f0f0);
-}
+
 
 .actionButton img {
     width: 24px;

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -70,3 +70,18 @@
     height: 24px;
     display: block;
 }
+
+
+/* 날짜 선택 드롭다운, 이미지저장, 되돌리기 버튼 */
+
+.dayDropdown{
+    display: flex;
+width: 83px;
+padding: 6px 8px;
+align-items: center;
+gap: 10px;
+flex-shrink: 0;
+border-radius: 4px;
+border: 1px solid var(--p-20, #C66CD9);
+background: var(--g-0, #FFF);
+}

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -1,163 +1,115 @@
-/* src/css/pages/timetable/timetabledetail.module.css */
-
 .pageContainer {
   display: flex;
   flex-direction: column;
-  
 }
-
-/* ========================================================= */
-/* 1. Header 및 제목 스타일 */
-/* ========================================================= */
 
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  /* (사용자 요청 속성 유지) 좌우 패딩이 0이므로, 버튼과 emptyBox에 마진/패딩을 추가하여 여백 확보 */
-  padding: 12px 0px; 
+  padding: 12px 0 0 0;
 }
 
-/* 뒤로 가기 버튼 초기화 */
 .backButton {
-  all: unset; 
+  all: unset;
   border: none;
   background: none;
   padding: 0;
   cursor: pointer;
-  outline: none; 
-  /* ⭐️ 추가: Header padding이 0px이므로 좌측 여백 확보 ⭐️ */
- 
+  outline: none;
 }
 
-/* 버튼 내부 이미지 크기 설정 */
 .backButton img {
-    width: 24px; 
+    width: 24px;
     height: 28px;
     flex-shrink: 0;
 }
 
-/* 페이지 제목: 중앙 정렬 및 줄임표 처리 */
 .pageTitle {
   flex-grow: 1;
   text-align: center;
-  overflow: hidden; 
-  white-space: nowrap; 
-  text-overflow: ellipsis; 
-
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   color: var(--g-100, #1a1a1a);
   font-family: Inter;
   font-size: 16px;
-  font-style: normal;
   font-weight: 500;
-  line-height: normal;
   letter-spacing: -0.48px;
-  
 }
 
-/* 제목 오른쪽을 채우는 빈 상자 (레이아웃 균형용) */
 .emptyBox{
-    width: 24px; 
+    width: 24px;
     height: 24px;
     display: block;
-    /* ⭐️ 추가: Header padding이 0px이므로 우측 여백 확보 ⭐️ */
-    
 }
 
-/* ========================================================= */
-/* 2. 타임테이블 컨트롤 바 (드롭다운 + 액션 버튼) */
-/* ========================================================= */
-
-/* ⭐️ 컨트롤 바 전체 컨테이너 (.timetableControlBar) ⭐️ */
 .timetableControlBar {
     display: flex;
-    justify-content: space-between; /* 드롭다운과 액션 버튼을 양 끝에 배치 */
+    justify-content: space-between;
     align-items: center;
     flex-shrink: 0;
     padding: 16px 0px;
 }
 
-/* ⭐️ 드롭다운 요소만 감싸는 래퍼 (.dropdownWrapper) - List의 absolute 기준점 ⭐️ */
 .dropdownWrapper {
-    position: relative; 
-    display: block; 
+    position: relative;
+    display: block;
 }
 
-/* 토글 버튼 (현재 선택된 날짜 표시 영역) */
 .dayDropdownToggle {
-    all: unset; 
-    
+    all: unset;
     box-sizing: border-box;
-    width: 83px; 
-    
+    width: 83px;
     display: flex;
     padding: 6px 8px;
     align-items: center;
-    justify-content: space-between; 
+    justify-content: space-between;
     gap: 10px;
     flex-shrink: 0;
     border-radius: 4px;
-   
-border: 1px solid var(--p-20, #C66CD9);
-background: var(--g-0, #FFF);
-    
+    border: 1px solid var(--p-20, #C66CD9);
     background: var(--g-0, #FFF);
     cursor: pointer;
-    
-    transition: border-color 0.2s; 
+    transition: border-color 0.2s;
     color: var(--p-20, #C66CD9);
-
-/* medium/12 */
-font-family: Inter;
-font-size: 12px;
-font-style: normal;
-font-weight: 500;
-line-height: normal;
-letter-spacing: -0.36px;
+    font-family: Inter;
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: -0.36px;
 }
 
-/* 토글 버튼 열림 상태 스타일 */
 .dayDropdownToggle.open {
     border: 1px solid var(--p-20, #C66CD9);
 }
 
 .dayDropdownToggle span {
-    flex-grow: 1; 
+    flex-grow: 1;
 }
 
-/* 선택된 날짜 (보라색 글꼴) */
 .fontSet {
-    color: var(--p-20, #C66CD9); 
+    color: var(--p-20, #C66CD9);
     font-family: Inter;
     font-size: 12px;
-    font-style: normal;
     font-weight: 500;
-    line-height: normal;
     letter-spacing: -0.36px;
     white-space: nowrap;
 }
 
-/* Placeholder/열림 상태 텍스트 ('날짜 선택') */
 .placeholderText {
     color: var(--g-40, #D1D1D1);
-
-/* regular/12 */
-font-family: Inter;
-font-size: 12px;
-font-style: normal;
-font-weight: 400;
-line-height: normal;
-letter-spacing: -0.36px;
+    font-family: Inter;
+    font-size: 12px;
+    font-weight: 400;
+    letter-spacing: -0.36px;
     white-space: nowrap;
-    
 }
 
-/* 화살표 아이콘 스타일 */
 .dayDropdownToggle img {
-    width: 16px; 
+    width: 16px;
     height: 16px;
     flex-shrink: 0;
-    transition: transform 0.3s ease; 
+    transition: transform 0.3s ease;
 }
 
 .arrowClosed {
@@ -168,95 +120,66 @@ letter-spacing: -0.36px;
     transform: rotate(180deg);
 }
 
-
-/* 1. 드롭다운 목록 (ul 태그) */
 .dayDropdownList {
-    position: absolute; 
-    
-    /* ⭐️ 수정: .dropdownWrapper 기준이므로 left: 0px ⭐️ */
-    left: 0px; 
-    z-index: 300; 
-    width: 83px; 
-    
-    padding: 0; 
+    position: absolute;
+    left: 0px;
+    z-index: 300;
+    width: 83px;
+    padding: 0;
     margin: 4px 0 0 0;
-    
-    border: 1px solid var(--p-20, #C66CD9); 
+    border: 1px solid var(--p-20, #C66CD9);
     border-radius: 4px;
     background-color: white;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
-/* 2. 목록의 각 항목 (li 태그) */
 .dayDropdownItem {
     width: 83px;
-
 }
 
-/* 3. 목록 내부의 날짜 선택 버튼 (실제 클릭 영역) */
 .dayDropdownOption {
-    all: unset; 
+    all: unset;
     display: block;
     width: 83px;
     padding: 8px 0px;
-    
-    
     cursor: pointer;
-    
     font-family: Inter;
-font-size: 12px;
-font-style: normal;
-font-weight: 500;
-line-height: normal;
-letter-spacing: -0.36px;
-    color: #333; 
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: -0.36px;
+    color: #333;
 }
-.textSpace 
-{
+
+.textSpace {
     padding-left:8px;
 }
 
-/* 4. 마우스 오버(hover) 및 선택(active) 스타일 */
 .dayDropdownOption:hover {
     background-color: #f7f7f7;
 }
 
-/* 현재 선택된 항목 스타일 */
 .dayDropdownOption.active {
-   background: var(--b-210, rgba(198, 108, 217, 0.10));
+    background: var(--b-210, rgba(198, 108, 217, 0.10));
     color: var(--p-20, #C66CD9);
-/* medium/12 */
-font-family: Inter;
-font-size: 12px;
-font-style: normal;
-font-weight: 500;
-line-height: normal;
-letter-spacing: -0.36px;
-
-
+    font-family: Inter;
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: -0.36px;
 }
 
-/* ========================================================= */
-/* 3. 액션 버튼 (다운로드/되돌리기) 스타일 */
-/* ========================================================= */
-
-/* ⭐️ 액션 버튼 래퍼 (.actionButtonWrapper) ⭐️ */
 .actionButtonWrapper {
     display: flex;
-    gap: 8px; /* 버튼 간격 */
+    gap: 8px;
     flex-shrink: 0;
 }
 
-/* ⭐️ 개별 액션 버튼 (.actionButton) ⭐️ */
 .actionButton {
     all: unset;
     cursor: pointer;
-    padding: 4px; 
+    padding: 4px;
     border-radius: 4px;
     transition: background-color 0.2s;
-    
-    /* Flex item으로 작동하도록 설정 */
-    display: flex; 
+    display: flex;
     align-items: center;
     justify-content: center;
 }
@@ -265,7 +188,6 @@ letter-spacing: -0.36px;
     background-color: var(--g-10, #f0f0f0);
 }
 
-/* ⭐️ 액션 버튼 내부 이미지 크기 ⭐️ */
 .actionButton img {
     width: 24px;
     height: 24px;
@@ -274,6 +196,6 @@ letter-spacing: -0.36px;
 
 .selectedDateTextWrapper {
    width: 67px;
-flex-shrink: 0;
-margin-left:8px;
+   flex-shrink: 0;
+   margin-left:8px;
 }

--- a/src/css/pages/timetable/timetabledetail.module.css
+++ b/src/css/pages/timetable/timetabledetail.module.css
@@ -3,6 +3,7 @@
 .pageContainer {
   display: flex;
   flex-direction: column;
+  
 }
 
 /* ========================================================= */

--- a/src/css/pages/timetable/timetablemain.module.css
+++ b/src/css/pages/timetable/timetablemain.module.css
@@ -22,7 +22,7 @@
   gap: 16px;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
-  min-width: 375px;
+  min-width: 354px;
 }
 
 

--- a/src/css/pages/timetable/timetablemain.module.css
+++ b/src/css/pages/timetable/timetablemain.module.css
@@ -22,7 +22,7 @@
   gap: 16px;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
-  min-width: 354px;
+  min-width: 375px;
 }
 
 

--- a/src/layout/HomeLayout.tsx
+++ b/src/layout/HomeLayout.tsx
@@ -4,7 +4,7 @@ import Header from "../components/Header";
 export default function HomeLayout() {
   return (
     <div>
-      <Header />
+    <Header />
       <Outlet />
     </div>
   );

--- a/src/pages/ConcertProfile.tsx
+++ b/src/pages/ConcertProfile.tsx
@@ -63,6 +63,13 @@ const ConcertProfile = () => {
     }
   };
 
+  // ⭐️ [추가] 타임테이블 커스텀 페이지로 이동하는 핸들러 ⭐️
+  const handleCustomizeClick = () => {
+    if (!detail) return;
+    // 경로: /main/timetable/customize/{festivalId}
+    navigate(`/main/timetable/customize/${detail.id}`);
+  };
+
   useEffect(() => {
     if (!mt20id) return;
 
@@ -226,7 +233,11 @@ const ConcertProfile = () => {
           </div>
 
           <div className={concertProfileStyle.detailRight}>
-            <button className={concertProfileStyle.detailButton}>
+            <button 
+              className={concertProfileStyle.detailButton}
+              // ⭐️ [수정] 타임테이블 커스텀 버튼에 핸들러 연결 ⭐️
+              onClick={handleCustomizeClick}
+            >
               타임테이블 커스텀
             </button>
 

--- a/src/pages/ConcertProfile.tsx
+++ b/src/pages/ConcertProfile.tsx
@@ -21,7 +21,6 @@ type LocationState = {
   liked?: boolean;
 };
 
-// ⭐️ [유지] 페스티벌을 나타내는 typeofcon 값 정의 (2로 가정) ⭐️
 const FESTIVAL_TYPE_CODE = 2; 
 
 
@@ -160,8 +159,8 @@ const ConcertProfile = () => {
     }
   };
 
-  // ⭐️ [유지] 페스티벌 여부를 확인하는 플래그 (렌더링 스타일 변경에 사용하지 않음) ⭐️
   const isFestival = typeofcon === FESTIVAL_TYPE_CODE;
+  console.log(isFestival);
 
   return (
     <div className={concertProfileStyle.page}>
@@ -250,10 +249,10 @@ const ConcertProfile = () => {
 
           <div className={concertProfileStyle.detailRight}>
             
-            {/* ⭐️ [수정] 버튼은 항상 같은 텍스트와 스타일로 렌더링됩니다. ⭐️ */}
+     
             <button 
               className={concertProfileStyle.detailButton}
-              // ⭐️ [수정] 클릭 시 handleCustomizeClick이 페스티벌 여부를 판단하여 페이지 이동 또는 알림을 실행합니다. ⭐️
+          
               onClick={handleCustomizeClick}
             >
               타임테이블 커스텀

--- a/src/pages/ConcertProfile.tsx
+++ b/src/pages/ConcertProfile.tsx
@@ -21,6 +21,10 @@ type LocationState = {
   liked?: boolean;
 };
 
+// ⭐️ [유지] 페스티벌을 나타내는 typeofcon 값 정의 (2로 가정) ⭐️
+const FESTIVAL_TYPE_CODE = 2; 
+
+
 const formatDateRange = (from?: string, to?: string) => {
   if (!from || !to) return "";
   const [fromY, fromM, fromD] = from.split("-");
@@ -63,10 +67,18 @@ const ConcertProfile = () => {
     }
   };
 
-  // ⭐️ [추가] 타임테이블 커스텀 페이지로 이동하는 핸들러 ⭐️
+  // ⭐️ [수정] handleCustomizeClick 함수: 페스티벌이 아닐 경우 모달(alert) 띄우고 종료 ⭐️
   const handleCustomizeClick = () => {
     if (!detail) return;
-    // 경로: /main/timetable/customize/{festivalId}
+    
+    // detail.typeofcon이 FESTIVAL_TYPE_CODE(2)가 아닐 경우
+    if (detail.typeofcon !== FESTIVAL_TYPE_CODE) {
+        // 페이지 이동 대신 알림 (모달) 창 띄우기
+        alert("이 공연은 타임테이블 구성이 불가능합니다.");
+        return; 
+    }
+    
+    // typeofcon이 2인 경우에만 타임테이블 커스텀 페이지로 이동
     navigate(`/main/timetable/customize/${detail.id}`);
   };
 
@@ -131,6 +143,7 @@ const ConcertProfile = () => {
     styurls,
     relates,
     locationUrl,
+    typeofcon, // typeofcon 값을 가져옵니다.
   } = detail;
 
   const ticketSite = relates?.[0];
@@ -147,9 +160,12 @@ const ConcertProfile = () => {
     }
   };
 
+  // ⭐️ [유지] 페스티벌 여부를 확인하는 플래그 (렌더링 스타일 변경에 사용하지 않음) ⭐️
+  const isFestival = typeofcon === FESTIVAL_TYPE_CODE;
+
   return (
     <div className={concertProfileStyle.page}>
-      {/* 헤더 */}
+     
       <div className={concertProfileStyle.header}>
         <HiChevronLeft
           className={concertProfileStyle.Vector}
@@ -158,7 +174,7 @@ const ConcertProfile = () => {
         <span className={concertProfileStyle.concertName}>{prfnm}</span>
       </div>
 
-      {/* 포스터 */}
+     
       <img
         src={poster || posterPlaceholder}
         className={concertProfileStyle.posterImg}
@@ -201,7 +217,7 @@ const ConcertProfile = () => {
           </div>
         </div>
 
-        {/* 상세 정보 섹션 */}
+    
         <div className={concertProfileStyle.infoSection2}>
         <div className={concertProfileStyle.detailSection}>
           <div className={concertProfileStyle.detailLeft}>
@@ -233,13 +249,16 @@ const ConcertProfile = () => {
           </div>
 
           <div className={concertProfileStyle.detailRight}>
+            
+            {/* ⭐️ [수정] 버튼은 항상 같은 텍스트와 스타일로 렌더링됩니다. ⭐️ */}
             <button 
               className={concertProfileStyle.detailButton}
-              // ⭐️ [수정] 타임테이블 커스텀 버튼에 핸들러 연결 ⭐️
+              // ⭐️ [수정] 클릭 시 handleCustomizeClick이 페스티벌 여부를 판단하여 페이지 이동 또는 알림을 실행합니다. ⭐️
               onClick={handleCustomizeClick}
             >
               타임테이블 커스텀
             </button>
+
 
             <button
               className={concertProfileStyle.detailButton}
@@ -257,7 +276,7 @@ const ConcertProfile = () => {
           </div>
         </div>
 
-        {/* 밴드 라인업 */}
+  
         <div className={concertProfileStyle.bandLineupSection}>
           <div className={concertProfileStyle.bandLineupTitle}>
             출연 밴드 라인업

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,12 +1,9 @@
-
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import type { Location } from "react-router-dom";
-//캡쳐도구
-import html2canvas from "html2canvas";
+
 import leftarrow from "../../assets/timetable/arrow-left.svg";
 import downarrow from "../../assets/timetable/arrow-down.svg";
-import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
 import TimetableGrid from "../../components/timetable/TimetableGrid";
@@ -39,7 +36,7 @@ export interface KopisFestivalItem {
   locationUrl: string;
   styurls: { relatenm: string; relateurl: string }[];
   relates: { relatenm: string; relateurl: string }[];
-  days: { date: string; open: TimeObject; close: TimeObject }[]; // Kopis days 타입
+  days: { date: string; open: TimeObject; close: TimeObject }[]; 
   slots: {
     date: string;
     stageId: string;
@@ -51,7 +48,7 @@ export interface KopisFestivalItem {
     minutes: number;
     img: string;
     note: string;
-  }[]; // Kopis slots 타입
+  }[]; 
   fesLinks: { relatenm: string; relateurl: string }[];
   artistPics: { date: string; relatenm: string; url: string }[];
 }
@@ -63,8 +60,8 @@ export interface CustomDetailAPIItem {
   prfpdto: string;
   fcltynm: string;
   locationUrl: string;
-  hasCustom: boolean; // 커스텀 내역 존재 여부
-  days: { date: string; open: TimeObject; close: TimeObject }[]; // my-detail days 타입
+  hasCustom: boolean; 
+  days: { date: string; open: TimeObject; close: TimeObject }[]; 
   slots: {
     date: string;
     stageId: string;
@@ -76,7 +73,7 @@ export interface CustomDetailAPIItem {
     minutes: number;
     img: string | null;
     note: string | null;
-    inverted?: boolean; // 사용자가 선택했는지 여부
+    inverted?: boolean; 
   }[];
   artistPics: { date: string; relatenm: string; url: string }[];
 }
@@ -120,7 +117,7 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
 
 type TimetableMode = "customize" | "my" | "view";
 
-// ⭐️ TimeObject 또는 string을 "HH:MM:SS" 문자열로 변환하는 헬퍼 함수 ⭐️
+
 const timeToTimeString = (time: any): string => {
   if (typeof time === "string") return time;
   const hour = time?.hour ?? 0;
@@ -130,7 +127,7 @@ const timeToTimeString = (time: any): string => {
     .padStart(2, "0")}:00`;
 };
 
-// ⭐️ 1. Kopis API 호출 및 데이터 변환 함수 (기본 데이터 로드) ⭐️
+
 async function fetchAndProcessTimetableDetail(
   festivalId: string | undefined,
   setCurrentDayIndex: (index: number) => void,
@@ -217,7 +214,7 @@ async function fetchAndProcessTimetableDetail(
   return processedData;
 }
 
-// ⭐️ 2. 사용자 커스텀 슬롯만 가져오는 함수 (my-detail API 사용) ⭐️
+
 async function fetchCustomSlots(
   mt20id: string,
   setActiveScheduleKeys: (keys: Set<string>) => void
@@ -463,53 +460,6 @@ export default function TimetableDetailPage() {
     setIsDropdownOpen(false); 
   };
 
-  
-  const handleCaptureAndDownload = async () => {
-    const inputElement = document.getElementById("timetable-capture-area");
-
-    if (!inputElement) {
-      alert(
-        "캡처 대상 요소를 찾을 수 없습니다."
-      );
-      return;
-    }
-
-   
-    const contentWidth = inputElement.scrollWidth;
-    const contentHeight = inputElement.scrollHeight;
-
-    try {
-      const canvas = await html2canvas(inputElement, {
-        useCORS: true,
-        scale: 2,
-        width: contentWidth,
-        height: contentHeight,
-        scrollX: 0,
-        scrollY: 0,
-        backgroundColor: "#ffffff",
-        windowWidth: contentWidth,
-        windowHeight: contentHeight,
-      });
-
-   
-      const image = canvas.toDataURL("image/png");
-      const a = document.createElement("a");
-      a.href = image;
-
-      const dateStr = selectedDayData
-        ? formatDayAndDayOfWeek(selectedDayData.date).replace(/[\.()]/g, "_")
-        : "";
-      a.download = `${detailData?.festivalTitle || "Timetable"}_${dateStr}.png`;
-
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-    } catch (error) {
-      alert(
-        "이미지 캡처 중 오류가 발생했습니다."
-      );
-    }
-  };
 
   const handleDaySelect = (index: number) => {
     setCurrentDayIndex(index);
@@ -602,12 +552,7 @@ export default function TimetableDetailPage() {
               )}
             </div>
             <div className={timetableStyles.actionButtonWrapper}>
-              <button
-                className={timetableStyles.actionButton}
-                onClick={handleCaptureAndDownload}
-              >
-                <img src={download} alt="이미지 캡처 및 다운로드" />
-              </button>
+              {/* 이미지 캡처/다운로드 버튼 제거됨 */}
               <button
                 className={timetableStyles.actionButton}
                 onClick={handleRefresh}

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -208,7 +208,7 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
     
-    // ⭐️ (최종 안전 수정 함수) ⭐️ 페이로드 생성 시 mt20id 중복 방지 및 필터링 적용
+    // ⭐️ (userId 제거) 페이로드: mt20id와 invertedSlots만 포함 ⭐️
     const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
         // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청을 할 수 없음
         if (!detailData || currentDayIndex === -1 || !detailData.mt20id) return { payload: null, hasSelections: false };
@@ -240,7 +240,7 @@ export default function TimetableDetailPage() {
         // 필터링 후에도 선택된 항목이 있는지 다시 확인
         const finalHasSelections = invertedSlots.length > 0;
         
-        // ⭐️⭐️ 수정 1: 객체를 단순하게 만들어 mt20id 중복 가능성을 제거 ⭐️⭐️
+        // ⭐️ userId 필드 제거 ⭐️
         const payload: { mt20id: string; invertedSlots: any[] } = {
             mt20id: detailData.mt20id, 
             invertedSlots: invertedSlots
@@ -282,6 +282,9 @@ export default function TimetableDetailPage() {
     
     // ⭐️ 핵심 저장 로직. 성공/건너뛰면 true, 실패하면 false 반환
     const saveTimetableData = async (): Promise<boolean> => { 
+        
+        // ❌ userId 확보 및 검증 로직 완전히 제거 ❌
+        
         const { payload, hasSelections } = getPayloadAndCheckSelection();
 
         // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청 건너뛰기
@@ -297,14 +300,14 @@ export default function TimetableDetailPage() {
 
         const mt20id = payload.mt20id;
         const API_ENDPOINT = `/festivals/${mt20id}/custom-slots`; 
-        const HTTP_METHOD = 'PUT'; 
+        const HTTP_METHOD = 'POST'; 
 
         console.log(`💾 Final Payload Ready for ${HTTP_METHOD} to ${API_ENDPOINT}:`, payload);
-        // ⭐️⭐️ 추가 로그: JSON.stringify로 실제 전송될 문자열 확인 (디버깅용) ⭐️⭐️
         console.log('⭐️ RAW JSON STRING:', JSON.stringify(payload)); 
 
         try {
-            const response = await api.put(API_ENDPOINT, payload); 
+            // ⭐️⭐️ api.post 호출 시, userId 쿼리 파라미터 전달 로직 제거 ⭐️⭐️
+            const response = await api.post(API_ENDPOINT, payload); 
 
             console.log(`✅ 타임테이블 저장 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, response.data);
             alert("나의 타임테이블이 성공적으로 서버에 저장되었습니다!");
@@ -312,14 +315,14 @@ export default function TimetableDetailPage() {
 
         } catch (error) {
             const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
-            // ⭐️ 500 에러 메시지 콘솔 출력 ⭐️
+            // ⭐️ 에러 발생 시 로그에서 userId 관련 정보 제거 ⭐️
             console.error(`❌ 타임테이블 저장 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error); 
             alert(`타임테이블 저장 중 오류가 발생했습니다: ${errorMessage}`);
             return false;
         }
     };
     
-    // ⭐️ 뒤로 가기 버튼 클릭 시 저장 로직 실행 후 이동
+    // ⭐️ 뒤로 가기 버튼 클릭 시 저장 로직이 포함된 handleGoBack 연결
     const handleGoBack = async () => {
         const saveSuccessful = await saveTimetableData();
 

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,21 +1,43 @@
+// src/pages/timetable/TimetableDetailPage.tsx (콘솔 로그 추가 버전)
+
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
+import type { Location } from "react-router-dom"; 
 import leftarrow from "../../assets/timetable/arrow-left.svg";
 import downarrow from "../../assets/timetable/arrow-down.svg";
 import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
 
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
-// TimetableGrid는 외부 컴포넌트이므로 실제 파일 구조에 따라 import 경로를 확인하세요.
 import TimetableGrid from "../../components/timetable/TimetableGrid"; 
+import api from "../../api/api"; 
 
+export interface KopisFestivalItem {
+  id: number; 
+  prfnm: string; 
+  prfpdfrom: string; 
+  prfpdto: string; 
+  fcltynm: string; 
+  days: { date: string; open: any; close: any; }[]; // 이제 사용하지 않음
+  slots: { 
+    date: string; stageId: string; stageName: string; stageOrder: number; 
+    artist: string; 
+    start: { hour: number; minute: number; second: number; nano: number; }; 
+    end: { hour: number; minute: number; second: number; nano: number; }; 
+    minutes: number; img: string | null; note: string | null; 
+  }[];
+}
 export interface ScheduleItem { 
   date: string; stageId: string; stageName: string; stageOrder: number; 
   artist: string; start: string; end: string; minutes: number; 
   img: string | null; note: string | null; isCustomized?: boolean; 
 }
 interface DayScheduleData { date: string; schedules: ScheduleItem[]; }
-interface FestivalDetailData { festivalId: number; festivalTitle: string; days: DayScheduleData[]; }
+interface FestivalDetailData { 
+    festivalId: number; 
+    festivalTitle: string; 
+    days: DayScheduleData[]; 
+}
 
 const formatDayAndDayOfWeek = (dateString: string): string => {
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
@@ -26,426 +48,116 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
     return `${month}.${day}(${dayOfWeek})`;
 };
 
-// 🌟 MockFestivalDetails 데이터: 전체 Mock 데이터를 올바르게 통합했습니다. 🌟
-const MockFestivalDetails: Record<number, FestivalDetailData> = { 
-     1: {
-    festivalId: 1,
-    festivalTitle: "그랜드 민트 페스티벌 2025",
-    days: [
-      {
-        date: "2025-12-20",
-        schedules: [
-          { date:"2025-12-20", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Artist 1", start:"15:00:00", end:"15:40:00", minutes:40, img:null, note:null },
-          { date:"2025-12-20", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Artist 2", start:"15:45:00", end:"16:25:00", minutes:40, img:null, note:null },
-          { date:"2025-12-20", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Artist 3", start:"16:30:00", end:"17:10:00", minutes:40, img:null, note:null },
-        ]
-      }
-    ]
-  },
-  2: {
-    festivalId: 2,
-    festivalTitle: "COUNTDOWN FANTASY 2025-2026",
-    days: [
-      {
-        date:"2025-12-30",
-        schedules:[
-          { date:"2025-12-30", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Countdown Artist 1", start:"20:00:00", end:"20:40:00", minutes:40, img:null, note:null },
-          { date:"2025-12-30", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Countdown Artist 2", start:"20:45:00", end:"21:25:00", minutes:40, img:null, note:null },
-          { date:"2025-12-30", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Countdown Artist 3", start:"21:30:00", end:"22:10:00", minutes:40, img:null, note:null },
-        ]
-      },
-      {
-        date:"2025-12-31",
-        schedules:[
-          { date:"2025-12-31", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Countdown Artist 4", start:"20:00:00", end:"20:40:00", minutes:40, img:null, note:null },
-          { date:"2025-12-31", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Countdown Artist 5", start:"20:45:00", end:"21:25:00", minutes:40, img:null, note:null },
-          { date:"2025-12-31", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Countdown Artist 6", start:"21:30:00", end:"22:10:00", minutes:40, img:null, note:null },
-        ]
-      }
-    ]
-  },
-  3: {
-    festivalId: 3,
-    festivalTitle: "COUNTDOWN FANTASY 2025-2026",
-    days: [
-      {
-      "date": "2025-10-20",
-      "schedules": [
-        {
-          "date": "2025-10-20",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "노브레인",
-          "start": "15:00:00",
-          "end": "15:40:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "선우정아",
-          "start": "15:45:00",
-          "end": "16:25:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "No Party for Cao Dong (TW)",
-          "start": "16:30:00",
-          "end": "17:10:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "Bandit Bandit (FR)",
-          "start": "17:15:00",
-          "end": "17:55:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "혁오",
-          "start": "18:00:00",
-          "end": "18:40:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "태버 (Tabber)",
-          "start": "18:45:00",
-          "end": "19:25:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "Colonel Mustard & The Dijon 5 (UK)",
-          "start": "19:30:00",
-          "end": "20:10:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "잔나비",
-          "start": "20:15:00",
-          "end": "20:55:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "넉살 X 까데호",
-          "start": "21:00:00",
-          "end": "21:40:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "No Buses (JP)",
-          "start": "21:45:00",
-          "end": "22:25:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-20",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "Yaeji (DJ Set)",
-          "start": "22:40:00",
-          "end": "23:30:00",
-          "minutes": 50,
-          "img": null,
-          "note": null
-        }
-      ]
-    },
-    {
-      "date": "2025-10-21",
-      "schedules": [
-        {
-          "date": "2025-10-21",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "장기하",
-          "start": "15:00:00",
-          "end": "15:40:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "Jambinai",
-          "start": "15:45:00",
-          "end": "16:25:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "설(SURL)",
-          "start": "16:30:00",
-          "end": "17:10:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "The fin. (JP)",
-          "start": "17:15:00",
-          "end": "17:55:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "새소년",
-          "start": "18:00:00",
-          "end": "18:40:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "The Volunteers",
-          "start": "18:45:00",
-          "end": "19:25:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "라이프 앤 타임",
-          "start": "19:30:00",
-          "end": "20:10:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "Peggy Gou",
-          "start": "20:15:00",
-          "end": "20:55:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "실리카겔",
-          "start": "21:00:00",
-          "end": "21:40:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "B-2",
-          "stageName": "Stage B",
-          "stageOrder": 2,
-          "artist": "이디오테잎",
-          "start": "21:45:00",
-          "end": "22:25:00",
-          "minutes": 40,
-          "img": null,
-          "note": null
-        },
-        {
-          "date": "2025-10-21",
-          "stageId": "A-1",
-          "stageName": "LAND STAGE (Stage A)",
-          "stageOrder": 1,
-          "artist": "250 (DJ Set)",
-          "start": "22:40:00",
-          "end": "23:30:00",
-          "minutes": 50,
-          "img": null,
-          "note": null
-        }
-      ]
-    }
-  ]
-  },
-  4: {
-    festivalId: 4,
-    festivalTitle: "DMZ 피스트레인 뮤직 페스티벌 2025",
-    days: [
-      {
-        date:"2025-12-20",
-        schedules:[
-          { date:"2025-12-20", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Busan Rock 1", start:"18:00:00", end:"18:40:00", minutes:40, img:null, note:null },
-          { date:"2025-12-20", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Busan Rock 2", start:"18:45:00", end:"19:25:00", minutes:40, img:null, note:null },
-          { date:"2025-12-20", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Busan Rock 3", start:"19:30:00", end:"20:10:00", minutes:40, img:null, note:null },
-        ]
-      }
-    ]
-  },
-  5: {
-    festivalId: 5,
-    festivalTitle: "2025 부산 락 페스티벌",
-    days: [
-      {
-        date:"2025-05-28",
-        schedules:[
-          { date:"2025-05-28", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Jazz 1", start:"17:00:00", end:"17:40:00", minutes:40, img:null, note:null },
-          { date:"2025-05-28", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Jazz 2", start:"17:45:00", end:"18:25:00", minutes:40, img:null, note:null },
-          { date:"2025-05-28", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Jazz 3", start:"18:30:00", end:"19:10:00", minutes:40, img:null, note:null },
-        ]
-      }
-    ]
-  },
-  6: {
-    festivalId: 6,
-    festivalTitle: "서울 재즈 페스티벌 2025",
-    days: [
-      {
-        date:"2025-08-15",
-        schedules:[
-          { date:"2025-08-15", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Hongdae 1", start:"16:00:00", end:"16:40:00", minutes:40, img:null, note:null },
-          { date:"2025-08-15", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Hongdae 2", start:"16:45:00", end:"17:25:00", minutes:40, img:null, note:null },
-          { date:"2025-08-15", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Hongdae 3", start:"17:30:00", end:"18:10:00", minutes:40, img:null, note:null },
-        ]
-      }
-    ]
-  },
-  7: {
-    festivalId: 7,
-    festivalTitle: "페스티벌 이름",
-    days: [
-      {
-        date:"2025-09-10",
-        schedules:[
-          { date:"2025-09-10", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"공연 이름", start:"15:00:00", end:"15:40:00", minutes:40, img:null, note:null },
-          { date:"2025-09-10", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"공연 이름", start:"15:45:00", end:"16:25:00", minutes:40, img:null, note:null },
-          { date:"2025-09-10", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"공연 이름", start:"16:30:00", end:"17:10:00", minutes:40, img:null, note:null },
-        ]
-      }
-    ]
-  }
-};
-
 type TimetableMode = 'customize' | 'my' | 'view'; 
 
-// ⭐️ 1. 데이터 로딩 함수 (외부로 분리, 깊은 복사 로직 포함) ⭐️
-async function fetchTimetableDetail(
+async function fetchAndProcessTimetableDetail(
     festivalId: string | undefined, 
     setCurrentDayIndex: (index: number) => void, 
     setDetailData: (data: FestivalDetailData | null) => void, 
     setIsLoading: (loading: boolean) => void
-) {
+): Promise<FestivalDetailData | null> {
     if (!festivalId) { 
+        console.log("❌ festivalId가 없습니다.");
         setIsLoading(false); 
-        return; 
+        return null;
     }
 
     setIsLoading(true);
+    const idNum = parseInt(festivalId, 10);
+    let processedData: FestivalDetailData | null = null;
+
     try {
-        await new Promise(resolve => setTimeout(resolve, 500));
-        const idNum = parseInt(festivalId);
-        // MockFestivalDetails[7]은 fallback 데이터입니다.
-        const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7];
+        const response = await api.get(`/kopis/performances/festivals?festivalId=${idNum}`); 
         
-        if (baseData) {
-            // ⭐ 핵심 로직: JSON을 이용한 깊은 복사 (Deep Copy) 수행 ⭐
-            const dataToLoad = JSON.parse(JSON.stringify(baseData)) as FestivalDetailData;
-            setDetailData(dataToLoad);
-            
-            if (dataToLoad.days.length > 0) {
-                // 데이터 로딩 완료 후 첫째 날을 선택
-                setCurrentDayIndex(0);
-            }
-        } else {
+        console.log("📌 API 전체 응답:", response.data);
+
+        const rawData = response.data.data || response.data;
+        console.log("📌 rawData:", rawData);
+
+        const apiData: KopisFestivalItem | undefined = Array.isArray(rawData)
+            ? rawData.find(f => f.id === idNum)
+            : rawData;
+
+        if (!apiData) {
+            console.error(`⚠️ festivalId ${festivalId}에 해당하는 데이터가 없습니다.`);
             setDetailData(null);
+            setIsLoading(false);
+            return null;
         }
+
+        const slots = apiData.slots || [];
+
+        if (!apiData.prfnm || slots.length === 0) { 
+             console.error("⚠️ 필수 필드 누락 또는 slots 없음", {
+                 prfnm: apiData?.prfnm,
+                 slotsLength: slots.length
+             });
+             setDetailData(null);
+             setIsLoading(false);
+             return null;
+        }
+
+        const schedulesByDateMap: Record<string, ScheduleItem[]> = {};
+
+        slots.forEach(slot => {
+            const dateString = slot.date;
+            const startHour = slot.start?.hour ?? 0;
+            const startMinute = slot.start?.minute ?? 0;
+            const endHour = slot.end?.hour ?? 0;
+            const endMinute = slot.end?.minute ?? 0;
+
+            const scheduleItem: ScheduleItem = {
+                date: slot.date,
+                stageId: slot.stageId,
+                stageName: slot.stageName,
+                stageOrder: slot.stageOrder,
+                artist: slot.artist,
+                start: `${startHour.toString().padStart(2,'0')}:${startMinute.toString().padStart(2,'0')}:00`,
+                end: `${endHour.toString().padStart(2,'0')}:${endMinute.toString().padStart(2,'0')}:00`,
+                minutes: slot.minutes,
+                img: slot.img || null,
+                note: slot.note || null,
+                isCustomized: false
+            };
+
+            if (!schedulesByDateMap[dateString]) schedulesByDateMap[dateString] = [];
+            schedulesByDateMap[dateString].push(scheduleItem);
+        });
+
+        console.log("📌 모든 ScheduleItem:", Object.values(schedulesByDateMap).flat());
+
+        const processedDays: DayScheduleData[] = Object.keys(schedulesByDateMap)
+            .sort()
+            .map(date => ({
+                date,
+                schedules: schedulesByDateMap[date]
+            }));
+
+        processedData = {
+            festivalId: idNum,
+            festivalTitle: apiData.prfnm,
+            days: processedDays
+        };
+        
+        console.log("✅ processedData:", processedData);
+
+        setDetailData(processedData);
+            
+        if (processedData.days.length > 0) setCurrentDayIndex(0);
+
     } catch (error) {
-        console.error("데이터 로드 중 오류 발생:", error);
+        console.error(`❌ 페스티벌 ID ${festivalId} 데이터를 불러오는 중 오류 발생:`, error);
         setDetailData(null);
     } finally { 
         setIsLoading(false); 
     }
+    return processedData;
 }
+
 
 export default function TimetableDetailPage() {
     const navigate = useNavigate();
-    const location = useLocation();
+    const location: Location<FestivalDetailData> = useLocation(); 
     const { id: festivalId } = useParams<{ id: string }>(); 
 
     const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
@@ -461,8 +173,6 @@ export default function TimetableDetailPage() {
 
     const allSchedules = useMemo(() => {
         if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
-        // isCustomized가 true인 스케줄만 필터링하는 등의 로직을 여기에 추가할 수 있습니다.
-        // 현재는 선택된 날짜의 모든 스케줄을 반환합니다.
         return detailData.days[currentDayIndex].schedules;
     }, [detailData, currentDayIndex]);
 
@@ -472,31 +182,34 @@ export default function TimetableDetailPage() {
             if (!stageMap[s.stageName]) stageMap[s.stageName] = [];
             stageMap[s.stageName].push(s);
         });
-        // StageOrder를 기반으로 스테이지 이름을 정렬하는 로직을 추가하면 좋습니다.
-        const stageNames: Record<string, string> = {};
-        Object.keys(stageMap).forEach((key, idx) => { stageNames[idx + ''] = key; });
+        
+        const uniqueStages = Array.from(new Set(allSchedules.map(s => JSON.stringify({ name: s.stageName, order: s.stageOrder }))));
+        const sortedStages = uniqueStages.map(s => JSON.parse(s)).sort((a, b) => a.order - b.order);
+        const stageNames: Record<string, string> = {}; 
+        sortedStages.forEach((stage, idx) => { stageNames[idx+''] = stage.name; });
+        
         return { stageMap, stageNames };
     }, [allSchedules]);
 
-    // ⭐ 초기 로딩 (useEffect에서 외부 함수 호출로 통일) ⭐
     useEffect(() => {
-        fetchTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
-    }, [festivalId, currentMode]);
+        console.log("🎯 현재 festivalId:", festivalId);
+        if (festivalId) {
+            fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
+        } else {
+             setIsLoading(false);
+             setDetailData(null); 
+        }
+    }, [festivalId]);
+
 
     const handleGoBack = () => navigate(-1);
     const handleDownload = () => console.log("Download clicked");
-   
-    // ⭐ Refresh 함수: 상태 초기화 및 데이터 재로드 로직 완성 ⭐
     const handleRefresh = () => {
-        console.log("Refresh button clicked! Resetting state and reloading data from Mock (Deep Copy).");
-        
-        // 1. 화면 상태 초기화 (날짜 선택을 리셋하여 로딩 상태를 확실히 하고, 드롭다운을 닫습니다.)
+        console.log("🔄 Refreshing data from API.");
         setCurrentDayIndex(-1); 
         setIsDropdownOpen(false);
-        
-        // 2. 데이터 로딩 함수를 다시 호출하여 원본 Mock 데이터를 '깊은 복사'하여 재로드합니다.
-        // 이를 통해 사용자의 커스터마이징 이전 상태로 안전하게 돌아갑니다.
-        fetchTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
+        if (festivalId) fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
+        else { setDetailData(null); setIsLoading(false); }
     };
 
     const handleDaySelect = (index: number) => { 
@@ -504,18 +217,9 @@ export default function TimetableDetailPage() {
         setIsDropdownOpen(false); 
     };
 
-    // 로딩 상태 처리
-    if (isLoading)
-        return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
-        
-    // 데이터 없음 상태 처리
-    if (!detailData || detailData.days.length === 0)
-        return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다.</div>;
-
-    // 데이터 정상 로드 후 현재 날짜가 선택되지 않았을 때 (초기 로드 중일 때)
-    if (currentDayIndex === -1 || !detailData.days[currentDayIndex])
-        return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
-
+    if (isLoading) return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
+    if (!detailData || detailData.days.length === 0) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다.</div>;
+    if (currentDayIndex === -1 || !detailData.days[currentDayIndex]) return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
 
     const selectedDayData = detailData.days[currentDayIndex];
     const selectedDateFormatted = formatDayAndDayOfWeek(selectedDayData.date);
@@ -547,7 +251,6 @@ export default function TimetableDetailPage() {
                                         <li key={index} className={timetableStyles.dayDropdownItem}>
                                             <button className={`${timetableStyles.dayDropdownOption} ${index===currentDayIndex? timetableStyles.active:''}`} onClick={()=>handleDaySelect(index)}>
                                                 <div className={timetableStyles.textSpace}>{formatDayAndDayOfWeek(day.date)}</div>
-                                                
                                             </button>
                                         </li>
                                     ))}
@@ -555,8 +258,12 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            <button className={timetableStyles.actionButton} onClick={handleDownload}><img src={download} alt="다운로드"/></button>
-                            <button className={timetableStyles.actionButton} onClick={handleRefresh}><img src={refresh} alt="되돌리기"/></button>
+                            <button className={timetableStyles.actionButton} onClick={handleDownload}>
+                                <img src={download} alt="다운로드"/>
+                            </button>
+                            <button className={timetableStyles.actionButton} onClick={handleRefresh}>
+                                <img src={refresh} alt="되돌리기"/>
+                            </button>
                         </div>
                     </div>
                 )}
@@ -565,7 +272,6 @@ export default function TimetableDetailPage() {
                 <div className={timetableStyles.timetableScrollWrapper}><div className={timetableStyles.scheduleArea}>
                         <TimetableGrid 
                             stageMap={schedulesByStage.stageMap} 
-                            stageNames={schedulesByStage.stageNames} 
                             allSchedules={allSchedules} 
                             mode={currentMode} 
                         />

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableDetailPage.tsx (콘솔 로그 추가 버전)
+// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 버전: 시간 타입 유연성 확보)
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -8,22 +8,24 @@ import downarrow from "../../assets/timetable/arrow-down.svg";
 import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
 
-import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
+import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; // 경로 확인 필요
 import TimetableGrid from "../../components/timetable/TimetableGrid"; 
 import api from "../../api/api"; 
 
+// ⭐️ Kopis API 응답 타입 (start/end를 객체 또는 문자열로 받도록 수정) ⭐️
 export interface KopisFestivalItem {
   id: number; 
   prfnm: string; 
   prfpdfrom: string; 
   prfpdto: string; 
   fcltynm: string; 
-  days: { date: string; open: any; close: any; }[]; // 이제 사용하지 않음
+  days: { date: string; open: any; close: any; }[]; 
   slots: { 
     date: string; stageId: string; stageName: string; stageOrder: number; 
     artist: string; 
-    start: { hour: number; minute: number; second: number; nano: number; }; 
-    end: { hour: number; minute: number; second: number; nano: number; }; 
+    // ⭐️ start와 end 필드를 객체이거나 문자열일 수 있도록 정의 ⭐️
+    start: string | { hour: number; minute: number; second: number; nano: number; }; 
+    end: string | { hour: number; minute: number; second: number; nano: number; }; 
     minutes: number; img: string | null; note: string | null; 
   }[];
 }
@@ -50,6 +52,7 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
 
 type TimetableMode = 'customize' | 'my' | 'view'; 
 
+// API 호출 및 데이터 변환 함수 
 async function fetchAndProcessTimetableDetail(
     festivalId: string | undefined, 
     setCurrentDayIndex: (index: number) => void, 
@@ -72,10 +75,8 @@ async function fetchAndProcessTimetableDetail(
         console.log("📌 API 전체 응답:", response.data);
 
         const rawData = response.data.data || response.data;
-        console.log("📌 rawData:", rawData);
-
         const apiData: KopisFestivalItem | undefined = Array.isArray(rawData)
-            ? rawData.find(f => f.id === idNum)
+            ? rawData.find(f => f.id === idNum) || rawData[0] // 배열일 경우 첫 번째 요소도 고려
             : rawData;
 
         if (!apiData) {
@@ -88,10 +89,7 @@ async function fetchAndProcessTimetableDetail(
         const slots = apiData.slots || [];
 
         if (!apiData.prfnm || slots.length === 0) { 
-             console.error("⚠️ 필수 필드 누락 또는 slots 없음", {
-                 prfnm: apiData?.prfnm,
-                 slotsLength: slots.length
-             });
+             console.error("⚠️ 필수 필드 누락 또는 slots 없음");
              setDetailData(null);
              setIsLoading(false);
              return null;
@@ -101,10 +99,32 @@ async function fetchAndProcessTimetableDetail(
 
         slots.forEach(slot => {
             const dateString = slot.date;
-            const startHour = slot.start?.hour ?? 0;
-            const startMinute = slot.start?.minute ?? 0;
-            const endHour = slot.end?.hour ?? 0;
-            const endMinute = slot.end?.minute ?? 0;
+            
+            // ⭐️⭐️ 시간 포맷팅 로직 수정: 문자열과 객체 모두 처리 ⭐️⭐️
+            let startString = "00:00:00";
+            let endString = "00:00:00";
+
+            // 1. start/end가 이미 문자열인 경우 (Main Page에서 본 유효한 형식)
+            if (typeof slot.start === 'string') {
+                startString = slot.start;
+            } 
+            // 2. start/end가 객체인 경우 (Detail Page의 인터페이스 형식)
+            else if (slot.start && typeof slot.start === 'object') {
+                const startHour = slot.start.hour ?? 0;
+                const startMinute = slot.start.minute ?? 0;
+                
+                // **주의:** 여기서 hour/minute이 0이라면 "00:00:00"이 되며, 이는 서버 데이터 문제
+                startString = `${startHour.toString().padStart(2,'0')}:${startMinute.toString().padStart(2,'0')}:00`;
+            }
+            
+            if (typeof slot.end === 'string') {
+                endString = slot.end;
+            } else if (slot.end && typeof slot.end === 'object') {
+                const endHour = slot.end.hour ?? 0;
+                const endMinute = slot.end.minute ?? 0;
+                endString = `${endHour.toString().padStart(2,'0')}:${endMinute.toString().padStart(2,'0')}:00`;
+            }
+
 
             const scheduleItem: ScheduleItem = {
                 date: slot.date,
@@ -112,8 +132,8 @@ async function fetchAndProcessTimetableDetail(
                 stageName: slot.stageName,
                 stageOrder: slot.stageOrder,
                 artist: slot.artist,
-                start: `${startHour.toString().padStart(2,'0')}:${startMinute.toString().padStart(2,'0')}:00`,
-                end: `${endHour.toString().padStart(2,'0')}:${endMinute.toString().padStart(2,'0')}:00`,
+                start: startString, // 수정된 문자열 사용
+                end: endString,     // 수정된 문자열 사용
                 minutes: slot.minutes,
                 img: slot.img || null,
                 note: slot.note || null,
@@ -124,7 +144,7 @@ async function fetchAndProcessTimetableDetail(
             schedulesByDateMap[dateString].push(scheduleItem);
         });
 
-        console.log("📌 모든 ScheduleItem:", Object.values(schedulesByDateMap).flat());
+        console.log("📌 모든 ScheduleItem:", Object.values(schedulesByDateMap).flat().slice(0, 5)); // 상위 5개만 로그 출력
 
         const processedDays: DayScheduleData[] = Object.keys(schedulesByDateMap)
             .sort()
@@ -183,6 +203,7 @@ export default function TimetableDetailPage() {
             stageMap[s.stageName].push(s);
         });
         
+        // 무대 순서에 따라 정렬 (TimetableGrid에서 사용됨)
         const uniqueStages = Array.from(new Set(allSchedules.map(s => JSON.stringify({ name: s.stageName, order: s.stageOrder }))));
         const sortedStages = uniqueStages.map(s => JSON.parse(s)).sort((a, b) => a.order - b.order);
         const stageNames: Record<string, string> = {}; 
@@ -217,6 +238,7 @@ export default function TimetableDetailPage() {
         setIsDropdownOpen(false); 
     };
 
+    // ⭐️ 로딩 및 에러 처리 조건부 렌더링 ⭐️
     if (isLoading) return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
     if (!detailData || detailData.days.length === 0) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다.</div>;
     if (currentDayIndex === -1 || !detailData.days[currentDayIndex]) return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -42,6 +42,43 @@ const MockFestivalDetails: Record<number, FestivalDetailData> = {
 };
 
 type TimetableMode = 'customize' | 'my' | 'view'; 
+// ⭐️ 2. 데이터 로딩 함수 (외부로 분리하여 Refresh 시 재호출 가능하도록 함) ⭐️
+async function fetchTimetableDetail(
+    festivalId: string | undefined, 
+    setCurrentDayIndex: (index: number) => void, 
+    setDetailData: (data: FestivalDetailData | null) => void, 
+    setIsLoading: (loading: boolean) => void
+) {
+    if (!festivalId) { 
+        setIsLoading(false); 
+        return; 
+    }
+
+    setIsLoading(true);
+    try {
+        await new Promise(resolve => setTimeout(resolve, 500));
+        const idNum = parseInt(festivalId);
+        const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7];
+        
+        if (baseData) {
+            // ⭐ 깊은 복사: 원본 Mock 데이터를 가져와 사용자 변경 사항을 덮어씁니다. ⭐
+            const dataToLoad = JSON.parse(JSON.stringify(baseData)) as FestivalDetailData;
+            setDetailData(dataToLoad);
+            
+            if (dataToLoad.days.length > 0) {
+                // 데이터 로딩 완료 후 첫째 날을 선택
+                setCurrentDayIndex(0);
+            }
+        } else {
+            setDetailData(null);
+        }
+    } catch (error) {
+        console.error("데이터 로드 중 오류 발생:", error);
+        setDetailData(null);
+    } finally { 
+        setIsLoading(false); 
+    }
+}
 
 export default function TimetableDetailPage() {
     const navigate = useNavigate();
@@ -98,7 +135,17 @@ export default function TimetableDetailPage() {
 
     const handleGoBack = () => navigate(-1);
     const handleDownload = () => console.log("Download clicked");
-    const handleRefresh = () => console.log("Refresh clicked");
+   // ⭐ Refresh 함수: 상태 초기화 및 데이터 재로드 ⭐
+    const handleRefresh = () => {
+        console.log("Refresh button clicked! Resetting state and reloading data.");
+        
+        // 1. 화면 상태 초기화 (옵션)
+        setCurrentDayIndex(-1); 
+        setIsDropdownOpen(false);
+        
+        // 2. 데이터 로딩 함수를 직접 호출하여 데이터 재로드 (가장 중요)
+        fetchTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
+    };
     const handleDaySelect = (index: number) => { setCurrentDayIndex(index); setIsDropdownOpen(false); };
 
     if (isLoading) return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,544 +1,640 @@
-// src/pages/timetable/TimetableDetailPage.tsx (순수 타임테이블 영역 캡처 최종 버전)
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import type { Location } from "react-router-dom"; 
-// ⭐️ [필수] html2canvas 임포트 (설치가 필요합니다: npm install html2canvas)
-import html2canvas from 'html2canvas';
-
+import type { Location } from "react-router-dom";
+//캡쳐도구
+import html2canvas from "html2canvas";
 import leftarrow from "../../assets/timetable/arrow-left.svg";
 import downarrow from "../../assets/timetable/arrow-down.svg";
 import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
-import TimetableGrid from "../../components/timetable/TimetableGrid"; 
-import api from "../../api/api"; // Axios 인스턴스
+import TimetableGrid from "../../components/timetable/TimetableGrid";
+import api from "../../api/api";
 
-// ⭐️ 시간 객체 타입 (공통 사용) ⭐️
 interface TimeObject {
-    hour: number;
-    minute: number;
-    second: number;
-    nano: number;
+  hour: number;
+  minute: number;
+  second: number;
+  nano: number;
 }
 
-
-// ⭐️ Kopis API 응답 타입 (기본 공연 정보) ⭐️
 export interface KopisFestivalItem {
-   id: number; 
-  mt20id: string; 
-  prfnm: string; 
-  prfpdfrom: string; 
-  prfpdto: string; 
-  fcltynm: string; 
-  prfruntime: string; 
-  prfage: string; 
-  pcseguidance: string; 
-  poster: string; 
-  prfstate: string; 
-  dtguidance: string; 
-  tkstdate: string; 
+  id: number;
+  mt20id: string;
+  prfnm: string;
+  prfpdfrom: string;
+  prfpdto: string;
+  fcltynm: string;
+  prfruntime: string;
+  prfage: string;
+  pcseguidance: string;
+  poster: string;
+  prfstate: string;
+  dtguidance: string;
+  tkstdate: string;
   tksttime: TimeObject;
   typeofcon: number;
   newstate: boolean;
   locationUrl: string;
-  styurls: { relatenm: string; relateurl: string; }[];
-  relates: { relatenm: string; relateurl: string; }[];
-  days: { date: string; open: TimeObject; close: TimeObject; }[]; // Kopis days 타입
-  slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: TimeObject; end: TimeObject; minutes: number; img: string; note: string; }[]; // Kopis slots 타입
-  fesLinks: { relatenm: string; relateurl: string; }[];
-  artistPics: { date: string; relatenm: string; url: string; }[];
+  styurls: { relatenm: string; relateurl: string }[];
+  relates: { relatenm: string; relateurl: string }[];
+  days: { date: string; open: TimeObject; close: TimeObject }[]; // Kopis days 타입
+  slots: {
+    date: string;
+    stageId: string;
+    stageName: string;
+    stageOrder: number;
+    artist: string;
+    start: TimeObject;
+    end: TimeObject;
+    minutes: number;
+    img: string;
+    note: string;
+  }[]; // Kopis slots 타입
+  fesLinks: { relatenm: string; relateurl: string }[];
+  artistPics: { date: string; relatenm: string; url: string }[];
 }
 
-// ⭐️ 서버의 /festivals/{mt20id}/my-detail 응답 타입 정의 ⭐️
 export interface CustomDetailAPIItem {
-    mt20id: string; 
-    prfnm: string; 
-    prfpdfrom: string; 
-    prfpdto: string; 
-    fcltynm: string; 
-    locationUrl: string;
-    hasCustom: boolean; // 커스텀 내역 존재 여부
-    days: { date: string; open: TimeObject; close: TimeObject; }[]; // my-detail days 타입
-    slots: { 
-        date: string; 
-        stageId: string; 
-        stageName: string; 
-        stageOrder: number; 
-        artist: string; 
-        start: TimeObject | string; 
-        end: TimeObject | string; 
-        minutes: number; 
-        img: string | null; 
-        note: string | null; 
-        inverted?: boolean; // 사용자가 선택했는지 여부
-    }[];
-    artistPics: { date: string; relatenm: string; url: string; }[];
+  mt20id: string;
+  prfnm: string;
+  prfpdfrom: string;
+  prfpdto: string;
+  fcltynm: string;
+  locationUrl: string;
+  hasCustom: boolean; // 커스텀 내역 존재 여부
+  days: { date: string; open: TimeObject; close: TimeObject }[]; // my-detail days 타입
+  slots: {
+    date: string;
+    stageId: string;
+    stageName: string;
+    stageOrder: number;
+    artist: string;
+    start: TimeObject | string;
+    end: TimeObject | string;
+    minutes: number;
+    img: string | null;
+    note: string | null;
+    inverted?: boolean; // 사용자가 선택했는지 여부
+  }[];
+  artistPics: { date: string; relatenm: string; url: string }[];
 }
 
-export interface ScheduleItem { 
-  date: string; stageId: string; stageName: string; stageOrder: number; 
-  artist: string; start: string; end: string; minutes: number; 
-  img: string | null; note: string | null; isCustomized?: boolean; 
+export interface ScheduleItem {
+  date: string;
+  stageId: string;
+  stageName: string;
+  stageOrder: number;
+  artist: string;
+  start: string;
+  end: string;
+  minutes: number;
+  img: string | null;
+  note: string | null;
+  isCustomized?: boolean;
 }
-interface DayScheduleData { date: string; schedules: ScheduleItem[]; }
-
-interface FestivalDetailData { 
-    festivalId: number; 
-    mt20id: string; // API 응답에서 받은 고유 ID
-    festivalTitle: string; 
-    days: DayScheduleData[]; 
+interface DayScheduleData {
+  date: string;
+  schedules: ScheduleItem[];
 }
 
-const createScheduleKey = (s: ScheduleItem) => `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
+interface FestivalDetailData {
+  festivalId: number;
+  mt20id: string; 
+  festivalTitle: string;
+  days: DayScheduleData[];
+}
+
+const createScheduleKey = (s: ScheduleItem) =>
+  `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
 
 const formatDayAndDayOfWeek = (dateString: string): string => {
-    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-    const date = new Date(dateString);
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
-    const dayOfWeek = weekdays[date.getDay()];
-    return `${month}.${day}(${dayOfWeek})`;
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+  const date = new Date(dateString);
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const dayOfWeek = weekdays[date.getDay()];
+  return `${month}.${day}(${dayOfWeek})`;
 };
 
-type TimetableMode = 'customize' | 'my' | 'view'; 
+type TimetableMode = "customize" | "my" | "view";
 
 // ⭐️ TimeObject 또는 string을 "HH:MM:SS" 문자열로 변환하는 헬퍼 함수 ⭐️
 const timeToTimeString = (time: any): string => {
-    if (typeof time === 'string') return time;
-    const hour = time?.hour ?? 0;
-    const minute = time?.minute ?? 0;
-    return `${hour.toString().padStart(2,'0')}:${minute.toString().padStart(2,'0')}:00`;
+  if (typeof time === "string") return time;
+  const hour = time?.hour ?? 0;
+  const minute = time?.minute ?? 0;
+  return `${hour.toString().padStart(2, "0")}:${minute
+    .toString()
+    .padStart(2, "0")}:00`;
 };
-
 
 // ⭐️ 1. Kopis API 호출 및 데이터 변환 함수 (기본 데이터 로드) ⭐️
 async function fetchAndProcessTimetableDetail(
-    festivalId: string | undefined, 
-    setCurrentDayIndex: (index: number) => void, 
-    setDetailData: (data: FestivalDetailData | null) => void, 
-    setIsLoading: (loading: boolean) => void
+  festivalId: string | undefined,
+  setCurrentDayIndex: (index: number) => void,
+  setDetailData: (data: FestivalDetailData | null) => void,
+  setIsLoading: (loading: boolean) => void
 ): Promise<FestivalDetailData | null> {
-    if (!festivalId) { 
-        console.log("❌ festivalId가 없습니다.");
-        setIsLoading(false); 
-        return null;
+  if (!festivalId) {
+    console.log("❌ festivalId가 없습니다.");
+    setIsLoading(false);
+    return null;
+  }
+
+  setIsLoading(true);
+  const idNum = parseInt(festivalId, 10);
+  let processedData: FestivalDetailData | null = null;
+
+  try {
+  
+    const response = await api.get(
+      `/kopis/performances/festivals?festivalId=${idNum}`
+    );
+
+    const rawData = response.data.data || response.data;
+    const apiData: KopisFestivalItem | undefined = Array.isArray(rawData)
+      ? rawData.find((f) => f.id === idNum) || rawData[0]
+      : rawData;
+
+    if (!apiData || !apiData.prfnm || (apiData.slots || []).length === 0) {
+      console.error(
+        `festivalId ${festivalId}에 해당하는 데이터가 없거나 필수 필드가 누락되었습니다.`
+      );
+      setDetailData(null);
+      setIsLoading(false);
+      return null;
     }
 
-    setIsLoading(true);
-    const idNum = parseInt(festivalId, 10);
-    let processedData: FestivalDetailData | null = null;
-    
-    try {
-        // Kopis API 엔드포인트 사용 (기본 데이터 구조 로드)
-        const response = await api.get(`/kopis/performances/festivals?festivalId=${idNum}`); 
-        
-        const rawData = response.data.data || response.data;
-        const apiData: KopisFestivalItem | undefined = Array.isArray(rawData)
-            ? rawData.find(f => f.id === idNum) || rawData[0] 
-            : rawData;
+    const mt20idValue = apiData.mt20id || festivalId;
 
-        if (!apiData || !apiData.prfnm || (apiData.slots || []).length === 0) {
-            console.error(`⚠️ festivalId ${festivalId}에 해당하는 데이터가 없거나 필수 필드가 누락되었습니다.`);
-            setDetailData(null);
-            setIsLoading(false);
-            return null;
-        }
-        
-        const mt20idValue = apiData.mt20id || festivalId;
+    const schedulesByDateMap: Record<string, ScheduleItem[]> = {};
 
-        const schedulesByDateMap: Record<string, ScheduleItem[]> = {};
+    apiData.slots.forEach((slot) => {
+      const dateString = slot.date;
 
-        apiData.slots.forEach(slot => {
-            const dateString = slot.date;
+      const scheduleItem: ScheduleItem = {
+        date: slot.date,
+        stageId: slot.stageId,
+        stageName: slot.stageName,
+        stageOrder: slot.stageOrder,
+        artist: slot.artist,
+        start: timeToTimeString(slot.start), 
+        end: timeToTimeString(slot.end), 
+        minutes: slot.minutes,
+        img: slot.img || null,
+        note: slot.note || null,
+        isCustomized: false,
+      };
 
-            const scheduleItem: ScheduleItem = {
-                date: slot.date,
-                stageId: slot.stageId,
-                stageName: slot.stageName,
-                stageOrder: slot.stageOrder, 
-                artist: slot.artist,
-                start: timeToTimeString(slot.start), // 헬퍼 함수 사용
-                end: timeToTimeString(slot.end),     // 헬퍼 함수 사용
-                minutes: slot.minutes,
-                img: slot.img || null,
-                note: slot.note || null,
-                isCustomized: false
-            };
+      if (!schedulesByDateMap[dateString]) schedulesByDateMap[dateString] = [];
+      schedulesByDateMap[dateString].push(scheduleItem);
+    });
 
-            if (!schedulesByDateMap[dateString]) schedulesByDateMap[dateString] = [];
-            schedulesByDateMap[dateString].push(scheduleItem);
-        });
+    const processedDays: DayScheduleData[] = Object.keys(schedulesByDateMap)
+      .sort()
+      .map((date) => ({ date, schedules: schedulesByDateMap[date] }));
 
-        const processedDays: DayScheduleData[] = Object.keys(schedulesByDateMap)
-            .sort()
-            .map(date => ({ date, schedules: schedulesByDateMap[date] }));
+    processedData = {
+      festivalId: idNum,
+      mt20id: mt20idValue,
+      festivalTitle: apiData.prfnm,
+      days: processedDays,
+    };
 
-        processedData = {
-            festivalId: idNum,
-            mt20id: mt20idValue,
-            festivalTitle: apiData.prfnm,
-            days: processedDays
-        };
-        
-        setDetailData(processedData);
-        if (processedData.days.length > 0) setCurrentDayIndex(0);
-
-    } catch (error) {
-        console.error(`❌ 페스티벌 ID ${festivalId} 데이터를 불러오는 중 오류 발생:`, error);
-        setDetailData(null);
-    } finally { 
-        setIsLoading(false); 
-    }
-    return processedData;
+    setDetailData(processedData);
+    if (processedData.days.length > 0) setCurrentDayIndex(0);
+  } catch (error) {
+    console.error(
+      `페스티벌 ID ${festivalId} 데이터를 불러오는 중 오류 발생:`,
+      error
+    );
+    setDetailData(null);
+  } finally {
+    setIsLoading(false);
+  }
+  return processedData;
 }
 
 // ⭐️ 2. 사용자 커스텀 슬롯만 가져오는 함수 (my-detail API 사용) ⭐️
 async function fetchCustomSlots(
-    mt20id: string,
-    setActiveScheduleKeys: (keys: Set<string>) => void
+  mt20id: string,
+  setActiveScheduleKeys: (keys: Set<string>) => void
 ): Promise<void> {
-    const API_URL = `/festivals/${mt20id}/my-detail`; 
-    
-    try {
-        const response = await api.get(API_URL);
-        const apiData: CustomDetailAPIItem = response.data.data || response.data; 
-        
-        const initialActiveKeys = new Set<string>();
+  const API_URL = `/festivals/${mt20id}/my-detail`;
 
-        if (apiData.hasCustom && Array.isArray(apiData.slots)) {
-            apiData.slots.forEach(slot => {
-                const startString = timeToTimeString(slot.start); // 헬퍼 함수 사용
-                
-                if (slot.inverted === true) {
-                     if (slot.artist) {
-                         const scheduleKey = `${slot.date}-${slot.stageId}-${slot.artist}-${startString}`;
-                         initialActiveKeys.add(scheduleKey);
-                     }
-                }
-            });
+  try {
+    const response = await api.get(API_URL);
+    const apiData: CustomDetailAPIItem = response.data.data || response.data;
+
+    const initialActiveKeys = new Set<string>();
+
+    if (apiData.hasCustom && Array.isArray(apiData.slots)) {
+      apiData.slots.forEach((slot) => {
+        const startString = timeToTimeString(slot.start); 
+
+        if (slot.inverted === true) {
+          if (slot.artist) {
+            const scheduleKey = `${slot.date}-${slot.stageId}-${slot.artist}-${startString}`;
+            initialActiveKeys.add(scheduleKey);
+          }
         }
-        
-        setActiveScheduleKeys(initialActiveKeys);
-        console.log(`✅ [GET ${API_URL}] 사용자 커스텀 슬롯 로드 성공. ${initialActiveKeys.size}개 활성화.`);
-
-    } catch (error) {
-        console.error(`❌ 사용자 커스텀 슬롯 (${API_URL}) 로드 중 오류 발생:`, error);
-        setActiveScheduleKeys(new Set()); 
+      });
     }
+
+    setActiveScheduleKeys(initialActiveKeys);
+    console.log(
+      `[GET ${API_URL}] 사용자 커스텀 슬롯 로드 성공. ${initialActiveKeys.size}개 활성화.`
+    );
+  } catch (error) {
+    console.error(`사용자 커스텀 슬롯 (${API_URL}) 로드 중 오류 발생:`, error);
+    setActiveScheduleKeys(new Set());
+  }
 }
 
-
 export default function TimetableDetailPage() {
-    const navigate = useNavigate();
-    const location: Location<FestivalDetailData> = useLocation(); 
-    const { id: festivalId } = useParams<{ id: string }>(); 
+  const navigate = useNavigate();
+  const location: Location<FestivalDetailData> = useLocation();
+  const { id: festivalId } = useParams<{ id: string }>();
 
-    const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [currentDayIndex, setCurrentDayIndex] = useState(-1);
-    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    
-    // 사용자가 선택한 스케줄 키를 저장하는 상태
-    const [activeScheduleKeys, setActiveScheduleKeys] = useState<Set<string>>(new Set());
-    
-    const handleScheduleToggle = (schedule: ScheduleItem) => {
-        const key = createScheduleKey(schedule);
-        
-        const newStateIsActive = !activeScheduleKeys.has(key); 
+  const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentDayIndex, setCurrentDayIndex] = useState(-1);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-        setActiveScheduleKeys(prev => {
-            const newSet = new Set(prev);
-            if (newSet.has(key)) {
-                newSet.delete(key); 
-            } else {
-                newSet.add(key); 
-            }
-            return newSet;
+  const [activeScheduleKeys, setActiveScheduleKeys] = useState<Set<string>>(
+    new Set()
+  );
+
+  const handleScheduleToggle = (schedule: ScheduleItem) => {
+    const key = createScheduleKey(schedule);
+
+    const newStateIsActive = !activeScheduleKeys.has(key);
+
+    setActiveScheduleKeys((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(key)) {
+        newSet.delete(key);
+      } else {
+        newSet.add(key);
+      }
+      return newSet;
+    });
+
+    console.log("--- Schedule Toggled ---");
+    console.log("Artist:", schedule.artist);
+    console.log("Inverted/Selected (New State):", newStateIsActive);
+    console.log("------------------------");
+  };
+
+  const currentMode: TimetableMode = useMemo(() => {
+    if (location.pathname.includes("/my/")) return "my";
+    if (location.pathname.includes("/customize/")) return "customize";
+    return "view";
+  }, [location.pathname]);
+
+  const getPayloadAndCheckSelection = useCallback((): {
+    payload: { mt20id: string; invertedSlots: any[] } | null;
+    hasSelections: boolean;
+  } => {
+    if (!detailData || !detailData.mt20id)
+      return { payload: null, hasSelections: false };
+
+    let allFestivalSchedules: ScheduleItem[] = [];
+    detailData.days.forEach((day) => {
+      allFestivalSchedules = allFestivalSchedules.concat(day.schedules);
+    });
+
+    const invertedSlots: any[] = [];
+    let finalHasSelections = false;
+
+    allFestivalSchedules.forEach((schedule) => {
+      const key = createScheduleKey(schedule);
+      const isInverted = activeScheduleKeys.has(key);
+
+      if (isInverted) {
+        finalHasSelections = true; 
+
+        invertedSlots.push({
+          date: schedule.date,
+          stageOrder: Number(schedule.stageOrder),
+          artist: schedule.artist,
+          inverted: isInverted,
         });
-        
-        console.log("--- Schedule Toggled ---");
-        console.log("Artist:", schedule.artist);
-        console.log("Inverted/Selected (New State):", newStateIsActive); 
-        console.log("------------------------");
+      }
+    });
+
+    const payload: { mt20id: string; invertedSlots: any[] } = {
+      mt20id: detailData.mt20id,
+      invertedSlots: invertedSlots,
     };
 
+    return { payload, hasSelections: finalHasSelections };
+  }, [detailData, activeScheduleKeys]);
 
-    const currentMode: TimetableMode = useMemo(() => {
-        if (location.pathname.includes('/my/')) return 'my';
-        if (location.pathname.includes('/customize/')) return 'customize';
-        return 'view'; 
-    }, [location.pathname]);
-    
-    const getPayloadAndCheckSelection = useCallback((): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
-        if (!detailData || !detailData.mt20id) return { payload: null, hasSelections: false };
-        
-        let allFestivalSchedules: ScheduleItem[] = [];
-        detailData.days.forEach(day => {
-            allFestivalSchedules = allFestivalSchedules.concat(day.schedules);
-        });
-        
-        const invertedSlots: any[] = [];
-        let finalHasSelections = false;
+  const allSchedules = useMemo(() => {
+    if (
+      !detailData ||
+      currentDayIndex === -1 ||
+      !detailData.days[currentDayIndex]
+    )
+      return [];
+    return detailData.days[currentDayIndex].schedules;
+  }, [detailData, currentDayIndex]);
 
-        allFestivalSchedules.forEach(schedule => {
-            const key = createScheduleKey(schedule);
-            const isInverted = activeScheduleKeys.has(key); 
-            
-            if (isInverted) {
-                finalHasSelections = true; // 하나라도 선택되면 true
-                
-                invertedSlots.push({
-                    date: schedule.date,
-                    stageOrder: Number(schedule.stageOrder), 
-                    artist: schedule.artist,
-                    inverted: isInverted 
-                });
-            }
-        });
-        
-        const payload: { mt20id: string; invertedSlots: any[] } = {
-            mt20id: detailData.mt20id, 
-            invertedSlots: invertedSlots 
-        };
-        
-        return { payload, hasSelections: finalHasSelections };
-    }, [detailData, activeScheduleKeys]);
+  const schedulesByStage = useMemo(() => {
+    const stageMap: Record<string, ScheduleItem[]> = {};
+    allSchedules.forEach((s) => {
+      if (!stageMap[s.stageName]) stageMap[s.stageName] = [];
+      stageMap[s.stageName].push(s);
+    });
 
-    const allSchedules = useMemo(() => {
-        if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
-        return detailData.days[currentDayIndex].schedules;
-    }, [detailData, currentDayIndex]);
-
-    const schedulesByStage = useMemo(() => {
-        const stageMap: Record<string, ScheduleItem[]> = {};
-        allSchedules.forEach(s => {
-            if (!stageMap[s.stageName]) stageMap[s.stageName] = [];
-            stageMap[s.stageName].push(s);
-        });
-        
-        const uniqueStages = Array.from(new Set(allSchedules.map(s => JSON.stringify({ name: s.stageName, order: s.stageOrder }))));
-        const sortedStages = uniqueStages.map(s => JSON.parse(s)).sort((a, b) => a.order - b.order);
-        const stageNames: Record<string, string> = {}; 
-        sortedStages.forEach((stage, idx) => { stageNames[idx+''] = stage.name; });
-        
-        return { stageMap, stageNames };
-    }, [allSchedules]);
-
-
-    // ⭐️ 1. Kopis API 호출 (기본 데이터 로드) ⭐️
-    useEffect(() => {
-        if (festivalId) {
-            fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
-        } else {
-             setIsLoading(false);
-             setDetailData(null); 
-        }
-    }, [festivalId]);
-    
-    // ⭐️ 2. detailData 로드 후, 커스텀 슬롯 API 호출 ⭐️
-    useEffect(() => {
-        if (detailData && detailData.mt20id && (currentMode === 'my' || currentMode === 'customize')) { 
-            fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
-        } else if (currentMode === 'view') {
-            setActiveScheduleKeys(new Set());
-        }
-    }, [detailData, currentMode]); 
-
-    // ⭐️⭐️ 저장/삭제 로직 ⭐️⭐️
-    const saveTimetableData = useCallback(async (): Promise<boolean> => { 
-        
-        const { payload, hasSelections } = getPayloadAndCheckSelection(); 
-
-        if (!payload || !payload.mt20id) {
-            console.error("⚠️ 저장할 데이터가 준비되지 않았습니다. (mt20id 누락)");
-            return false;
-        }
-        
-        const mt20id = payload.mt20id;
-        const API_ENDPOINT = `/festivals/${mt20id}/custom-slots`; 
-        const HTTP_METHOD = 'POST'; 
-
-        if (!hasSelections) {
-             console.log("ℹ️ 선택된 스케줄이 없어, 커스텀 슬롯 삭제 요청을 서버에 보냅니다. (빈 배열 POST)");
-        } else {
-            console.log(`💾 ${payload.invertedSlots.length}개 슬롯 저장 요청을 보냅니다.`);
-        }
-
-        try {
-            const response = await api.post(API_ENDPOINT, payload); 
-
-            const successMessage = hasSelections 
-                ? "나의 타임테이블이 성공적으로 서버에 저장되었습니다. 🥳" 
-                : "나의 타임테이블이 성공적으로 서버에서 삭제되었습니다. 🗑️";
-                
-            console.log(`✅ 타임테이블 저장/삭제 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, successMessage, response.data);
-            return true;
-
-        } catch (error) {
-            const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
-            
-            console.error(`❌ 타임테이블 저장/삭제 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, errorMessage, error); 
-            return false;
-        }
-    }, [getPayloadAndCheckSelection]);
-    
-    // 뒤로 가기 버튼 클릭 시 저장 로직이 포함된 handleGoBack 연결
-    const handleGoBack = async () => {
-        if (currentMode === 'customize' || currentMode === 'my') { 
-            const saveSuccessful = await saveTimetableData();
-             if (saveSuccessful) {
-                // 저장 성공 시에만 뒤로 이동
-                navigate(-1);
-            } else {
-                console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
-            }
-        } else {
-             navigate(-1);
-        }
-    };
-    
-    // ⭐️⭐️ Refresh 로직: 현재 로컬 선택 상태 초기화 ⭐️⭐️
-    const handleRefresh = () => {
-        console.log("🔄 Refresh 버튼 클릭: 현재 로컬에서 선택된 모든 스케줄을 초기화합니다.");
-        
-        setActiveScheduleKeys(new Set()); // 모든 선택 상태를 빈 Set으로 초기화
-        setIsDropdownOpen(false); // 드롭다운 닫기
-    };
-
-    // ⭐️⭐️ [FIX] 캡처 로직 (순수 타임테이블 영역만 캡처 최종) ⭐️⭐️
-    const handleCaptureAndDownload = async () => {
-        console.log("📸 이미지 캡처 시작 (순수 타임테이블 영역)...");
-        
-        const inputElement = document.getElementById('timetable-capture-area');
-
-        if (!inputElement) {
-            console.error("⚠️ 캡처 대상 요소를 찾을 수 없습니다. (ID: timetable-capture-area)");
-            // 사용자에게 피드백 제공
-            alert("캡처 대상 요소를 찾을 수 없습니다. 개발자에게 문의하거나 페이지를 새로고침 해보세요.");
-            return;
-        }
-        
-        // 캡처 대상 요소의 정확한 스크롤 크기를 가져옴
-        const contentWidth = inputElement.scrollWidth;
-        const contentHeight = inputElement.scrollHeight;
-
-        try {
-            const canvas = await html2canvas(inputElement, {
-                useCORS: true, 
-                scale: 2,       
-                
-                // ⭐️ 캡처할 영역의 실제 콘텐츠 크기만 지정 (잘림 방지) ⭐️
-                width: contentWidth,
-                height: contentHeight,
-                
-                // 캡처 시작점을 요소의 왼쪽 상단(0, 0)으로 고정
-                scrollX: 0,
-                scrollY: 0,
-                
-                // ⭐️ 배경색을 흰색으로 명시하여 주변의 불필요한 투명 여백 방지 ⭐️
-                backgroundColor: '#ffffff', 
-                
-                // 캡처가 뷰포트 크기에 종속되지 않도록 콘텐츠 크기로 뷰포트 옵션을 대체
-                windowWidth: contentWidth, 
-                windowHeight: contentHeight, 
-            });
-
-            // 다운로드 링크 생성 및 클릭
-            const image = canvas.toDataURL('image/png');
-            const a = document.createElement('a');
-            a.href = image;
-            
-            const dateStr = selectedDayData ? formatDayAndDayOfWeek(selectedDayData.date).replace(/[\.()]/g, '_') : '';
-            a.download = `${detailData?.festivalTitle || 'Timetable'}_${dateStr}.png`;
-            
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-
-            console.log("✅ 이미지 다운로드 성공.");
-            
-        } catch (error) {
-            console.error("❌ 이미지 캡처 중 오류 발생:", error);
-            alert("이미지 캡처 중 오류가 발생했습니다. 브라우저 호환성 또는 CSS 설정을 확인해 주세요.");
-        }
-    };
-    
-    const handleDaySelect = (index: number) => { 
-        setCurrentDayIndex(index); 
-        setIsDropdownOpen(false); 
-    };
-
-    if (isLoading) return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
-    if (!detailData || detailData.days.length === 0 || !detailData.mt20id) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다. (ID 누락 확인)</div>;
-    if (currentDayIndex === -1 || !detailData.days[currentDayIndex]) return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
-
-    const selectedDayData = detailData.days[currentDayIndex];
-    const selectedDateFormatted = formatDayAndDayOfWeek(selectedDayData.date);
-    const toggleButtonText = isDropdownOpen ? "날짜 선택" : selectedDateFormatted;
-    const toggleClass = `${timetableStyles.dayDropdownToggle} ${isDropdownOpen ? timetableStyles.open : ''}`;
-    const textClass = currentDayIndex !== -1 && !isDropdownOpen ? timetableStyles.fontSet : timetableStyles.placeholderText;
-
-    return (
-        <div className={timetableStyles.pageContainer}>
-            <header className={timetableStyles.header}>
-                <button className={timetableStyles.backButton} onClick={handleGoBack}>
-                    <img src={leftarrow} alt="뒤로 가기" />
-                </button>
-                <h1 className={timetableStyles.pageTitle}>{detailData.festivalTitle}</h1>
-                <div className={timetableStyles.emptyBox}></div>
-            </header>
-
-            <main className={timetableStyles.mainContent}>
-                {detailData.days.length > 0 && (
-                    <div className={timetableStyles.timetableControlBar}>
-                        <div className={timetableStyles.dropdownWrapper}>
-                            <button className={toggleClass} onClick={() => {if (detailData.days.length <= 1) return;setIsDropdownOpen(prev => !prev)}}>
-                                <span className={textClass}>{toggleButtonText}</span>
-                                <img src={downarrow} alt="드롭다운 화살표" className={isDropdownOpen ? timetableStyles.arrowOpen : timetableStyles.arrowClosed}/>
-                            </button>
-                            {isDropdownOpen && (
-                                <ul className={timetableStyles.dayDropdownList}>
-                                    {detailData.days.map((day, index) => (
-                                        <li key={index} className={timetableStyles.dayDropdownItem}>
-                                            <button className={`${timetableStyles.dayDropdownOption} ${index===currentDayIndex? timetableStyles.active:''}`} onClick={()=>handleDaySelect(index)}>
-                                                <div className={timetableStyles.textSpace}>{formatDayAndDayOfWeek(day.date)}</div>
-                                            </button>
-                                        </li>
-                                    ))}
-                                </ul>
-                            )}
-                        </div>
-                        <div className={timetableStyles.actionButtonWrapper}>
-                            {/* ⭐️ Download 아이콘에 캡처 함수 연결 ⭐️ */}
-                            <button className={timetableStyles.actionButton} onClick={handleCaptureAndDownload}>
-                                <img src={download} alt="이미지 캡처 및 다운로드" />
-                            </button>
-                            {/* Refresh 버튼 (로컬 선택 초기화) */}
-                            <button className={timetableStyles.actionButton} onClick={handleRefresh}>
-                                <img src={refresh} alt="되돌리기"/>
-                            </button>
-                        </div>
-                    </div>
-                )}
-
-                {currentDayIndex !== -1 && (
-                <div className={timetableStyles.timetableScrollWrapper}>
-                    {/* ⭐️ [캡처 대상] 순수한 TimetableGrid 콘텐츠 전체를 포함하는 영역 ⭐️ */}
-                    <div id="timetable-capture-area" className={timetableStyles.scheduleArea}>
-                        <TimetableGrid 
-                            stageMap={schedulesByStage.stageMap} 
-                            allSchedules={allSchedules} 
-                            mode={currentMode} 
-                            onScheduleToggle={handleScheduleToggle}
-                            activeScheduleKeys={activeScheduleKeys}
-                        />
-                    </div>
-                </div>
-                    
-                )}
-                
-            </main>
-        </div>
+    const uniqueStages = Array.from(
+      new Set(
+        allSchedules.map((s) =>
+          JSON.stringify({ name: s.stageName, order: s.stageOrder })
+        )
+      )
     );
+    const sortedStages = uniqueStages
+      .map((s) => JSON.parse(s))
+      .sort((a, b) => a.order - b.order);
+    const stageNames: Record<string, string> = {};
+    sortedStages.forEach((stage, idx) => {
+      stageNames[idx + ""] = stage.name;
+    });
+
+    return { stageMap, stageNames };
+  }, [allSchedules]);
+
+  useEffect(() => {
+    if (festivalId) {
+      fetchAndProcessTimetableDetail(
+        festivalId,
+        setCurrentDayIndex,
+        setDetailData,
+        setIsLoading
+      );
+    } else {
+      setIsLoading(false);
+      setDetailData(null);
+    }
+  }, [festivalId]);
+
+  useEffect(() => {
+    if (
+      detailData &&
+      detailData.mt20id &&
+      (currentMode === "my" || currentMode === "customize")
+    ) {
+      fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
+    } else if (currentMode === "view") {
+      setActiveScheduleKeys(new Set());
+    }
+  }, [detailData, currentMode]);
+
+ 
+  const saveTimetableData = useCallback(async (): Promise<boolean> => {
+    const { payload, hasSelections } = getPayloadAndCheckSelection();
+
+    if (!payload || !payload.mt20id) {
+      console.error("⚠️ 저장할 데이터가 준비되지 않았습니다. (mt20id 누락)");
+      return false;
+    }
+
+    const mt20id = payload.mt20id;
+    const API_ENDPOINT = `/festivals/${mt20id}/custom-slots`;
+    const HTTP_METHOD = "POST";
+
+    if (!hasSelections) {
+      console.log(
+        "선택된 스케줄이 없어, 커스텀 슬롯 삭제 요청을 서버에 보냅니다. (빈 배열 POST)"
+      );
+    } else {
+      console.log(
+        `💾 ${payload.invertedSlots.length}개 슬롯 저장 요청을 보냅니다.`
+      );
+    }
+
+    try {
+      const response = await api.post(API_ENDPOINT, payload);
+
+      const successMessage = hasSelections
+        ? "나의 타임테이블이 성공적으로 서버에 저장되었습니다."
+        : "나의 타임테이블이 성공적으로 서버에서 삭제되었습니다.";
+
+      console.log(
+        `타임테이블 저장/삭제 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`,
+        successMessage,
+        response.data
+      );
+      return true;
+    } catch (error) {
+      const errorMessage =
+        (error as any).response?.data?.message ||
+        "알 수 없는 오류가 발생했습니다.";
+
+      console.error(
+        `타임테이블 저장/삭제 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`,
+        errorMessage,
+        error
+      );
+      return false;
+    }
+  }, [getPayloadAndCheckSelection]);
+
+  const handleGoBack = async () => {
+    if (currentMode === "customize" || currentMode === "my") {
+      const saveSuccessful = await saveTimetableData();
+      if (saveSuccessful) {
+        navigate(-1);
+      } else {
+        console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
+      }
+    } else {
+      navigate(-1);
+    }
+  };
+
+
+  const handleRefresh = () => {
+    setActiveScheduleKeys(new Set()); 
+    setIsDropdownOpen(false); 
+  };
+
+  
+  const handleCaptureAndDownload = async () => {
+    const inputElement = document.getElementById("timetable-capture-area");
+
+    if (!inputElement) {
+      alert(
+        "캡처 대상 요소를 찾을 수 없습니다."
+      );
+      return;
+    }
+
+   
+    const contentWidth = inputElement.scrollWidth;
+    const contentHeight = inputElement.scrollHeight;
+
+    try {
+      const canvas = await html2canvas(inputElement, {
+        useCORS: true,
+        scale: 2,
+        width: contentWidth,
+        height: contentHeight,
+        scrollX: 0,
+        scrollY: 0,
+        backgroundColor: "#ffffff",
+        windowWidth: contentWidth,
+        windowHeight: contentHeight,
+      });
+
+   
+      const image = canvas.toDataURL("image/png");
+      const a = document.createElement("a");
+      a.href = image;
+
+      const dateStr = selectedDayData
+        ? formatDayAndDayOfWeek(selectedDayData.date).replace(/[\.()]/g, "_")
+        : "";
+      a.download = `${detailData?.festivalTitle || "Timetable"}_${dateStr}.png`;
+
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } catch (error) {
+      alert(
+        "이미지 캡처 중 오류가 발생했습니다."
+      );
+    }
+  };
+
+  const handleDaySelect = (index: number) => {
+    setCurrentDayIndex(index);
+    setIsDropdownOpen(false);
+  };
+
+  if (isLoading)
+    return (
+      <div className={timetableStyles.pageContainer}>
+        데이터를 불러오는 중입니다...
+      </div>
+    );
+  if (!detailData || detailData.days.length === 0 || !detailData.mt20id)
+    return (
+      <div className={timetableStyles.pageContainer}>
+        존재하지 않는 페스티벌이거나 데이터가 없습니다. (ID 누락 확인)
+      </div>
+    );
+  if (currentDayIndex === -1 || !detailData.days[currentDayIndex])
+    return (
+      <div className={timetableStyles.pageContainer}>
+        날짜 데이터를 준비 중입니다...
+      </div>
+    );
+
+  const selectedDayData = detailData.days[currentDayIndex];
+  const selectedDateFormatted = formatDayAndDayOfWeek(selectedDayData.date);
+  const toggleButtonText = isDropdownOpen ? "날짜 선택" : selectedDateFormatted;
+  const toggleClass = `${timetableStyles.dayDropdownToggle} ${
+    isDropdownOpen ? timetableStyles.open : ""
+  }`;
+  const textClass =
+    currentDayIndex !== -1 && !isDropdownOpen
+      ? timetableStyles.fontSet
+      : timetableStyles.placeholderText;
+
+  return (
+    <div className={timetableStyles.pageContainer}>
+      <header className={timetableStyles.header}>
+        <button className={timetableStyles.backButton} onClick={handleGoBack}>
+          <img src={leftarrow} alt="뒤로 가기" />
+        </button>
+        <h1 className={timetableStyles.pageTitle}>
+          {detailData.festivalTitle}
+        </h1>
+        <div className={timetableStyles.emptyBox}></div>
+      </header>
+
+      <main className={timetableStyles.mainContent}>
+        {detailData.days.length > 0 && (
+          <div className={timetableStyles.timetableControlBar}>
+            <div className={timetableStyles.dropdownWrapper}>
+              <button
+                className={toggleClass}
+                onClick={() => {
+                  if (detailData.days.length <= 1) return;
+                  setIsDropdownOpen((prev) => !prev);
+                }}
+              >
+                <span className={textClass}>{toggleButtonText}</span>
+                <img
+                  src={downarrow}
+                  alt="드롭다운 화살표"
+                  className={
+                    isDropdownOpen
+                      ? timetableStyles.arrowOpen
+                      : timetableStyles.arrowClosed
+                  }
+                />
+              </button>
+              {isDropdownOpen && (
+                <ul className={timetableStyles.dayDropdownList}>
+                  {detailData.days.map((day, index) => (
+                    <li key={index} className={timetableStyles.dayDropdownItem}>
+                      <button
+                        className={`${timetableStyles.dayDropdownOption} ${
+                          index === currentDayIndex
+                            ? timetableStyles.active
+                            : ""
+                        }`}
+                        onClick={() => handleDaySelect(index)}
+                      >
+                        <div className={timetableStyles.textSpace}>
+                          {formatDayAndDayOfWeek(day.date)}
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className={timetableStyles.actionButtonWrapper}>
+              <button
+                className={timetableStyles.actionButton}
+                onClick={handleCaptureAndDownload}
+              >
+                <img src={download} alt="이미지 캡처 및 다운로드" />
+              </button>
+              <button
+                className={timetableStyles.actionButton}
+                onClick={handleRefresh}
+              >
+                <img src={refresh} alt="되돌리기" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {currentDayIndex !== -1 && (
+          <div className={timetableStyles.timetableScrollWrapper}>
+            <div
+              id="timetable-capture-area"
+              className={timetableStyles.scheduleArea}
+            >
+              <TimetableGrid
+                stageMap={schedulesByStage.stageMap}
+                allSchedules={allSchedules}
+                mode={currentMode}
+                onScheduleToggle={handleScheduleToggle}
+                activeScheduleKeys={activeScheduleKeys}
+              />
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
 }

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -6,7 +6,8 @@ import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
 
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
-import TimetableGrid from "../../components/timetable/TimetableGrid";
+// TimetableGrid는 외부 컴포넌트이므로 실제 파일 구조에 따라 import 경로를 확인하세요.
+import TimetableGrid from "../../components/timetable/TimetableGrid"; 
 
 export interface ScheduleItem { 
   date: string; stageId: string; stageName: string; stageOrder: number; 
@@ -25,24 +26,385 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
     return `${month}.${day}(${dayOfWeek})`;
 };
 
+// 🌟 MockFestivalDetails 데이터: 전체 Mock 데이터를 올바르게 통합했습니다. 🌟
 const MockFestivalDetails: Record<number, FestivalDetailData> = { 
-    7: { 
-        festivalId: 7, 
-        festivalTitle: "더 많은 페스티벌 1 (3 스테이지)", 
-        days: [{ 
-            date: "2025-12-20", schedules: [
-                { date: "2025-12-20", stageId: "A-1", stageName: "LAND STAGE A", stageOrder: 1, artist: "단편선 순간들", start: "15:00:00", end: "15:40:00", minutes: 40, img: null, note: null, isCustomized: true },
-                { date: "2025-12-20", stageId: "A-1", stageName: "LAND STAGE A", stageOrder: 1, artist: "구남과여라이딩스텔라", start: "17:00:00", end: "17:40:00", minutes: 40, img: null, note: null, isCustomized: true },
-                { date: "2025-12-20", stageId: "B-2", stageName: "LAND STAGE B", stageOrder: 2, artist: "사위", start: "15:45:00", end: "16:25:00", minutes: 40, img: null, note: null, isCustomized: true },
-                { date: "2025-12-20", stageId: "B-2", stageName: "LAND STAGE B", stageOrder: 2, artist: "초록불꽃소년단", start: "17:45:00", end: "18:25:00", minutes: 40, img: null, note: null, isCustomized: true },
-                { date: "2025-12-20", stageId: "C-3", stageName: "LAND STAGE C", stageOrder: 3, artist: "THE CHAIRS", start: "16:30:00", end: "17:10:00", minutes: 40, img: null, note: null },
-            ] 
-        }],
+     1: {
+    festivalId: 1,
+    festivalTitle: "그랜드 민트 페스티벌 2025",
+    days: [
+      {
+        date: "2025-12-20",
+        schedules: [
+          { date:"2025-12-20", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Artist 1", start:"15:00:00", end:"15:40:00", minutes:40, img:null, note:null },
+          { date:"2025-12-20", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Artist 2", start:"15:45:00", end:"16:25:00", minutes:40, img:null, note:null },
+          { date:"2025-12-20", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Artist 3", start:"16:30:00", end:"17:10:00", minutes:40, img:null, note:null },
+        ]
+      }
+    ]
+  },
+  2: {
+    festivalId: 2,
+    festivalTitle: "COUNTDOWN FANTASY 2025-2026",
+    days: [
+      {
+        date:"2025-12-30",
+        schedules:[
+          { date:"2025-12-30", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Countdown Artist 1", start:"20:00:00", end:"20:40:00", minutes:40, img:null, note:null },
+          { date:"2025-12-30", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Countdown Artist 2", start:"20:45:00", end:"21:25:00", minutes:40, img:null, note:null },
+          { date:"2025-12-30", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Countdown Artist 3", start:"21:30:00", end:"22:10:00", minutes:40, img:null, note:null },
+        ]
+      },
+      {
+        date:"2025-12-31",
+        schedules:[
+          { date:"2025-12-31", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Countdown Artist 4", start:"20:00:00", end:"20:40:00", minutes:40, img:null, note:null },
+          { date:"2025-12-31", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Countdown Artist 5", start:"20:45:00", end:"21:25:00", minutes:40, img:null, note:null },
+          { date:"2025-12-31", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Countdown Artist 6", start:"21:30:00", end:"22:10:00", minutes:40, img:null, note:null },
+        ]
+      }
+    ]
+  },
+  3: {
+    festivalId: 3,
+    festivalTitle: "COUNTDOWN FANTASY 2025-2026",
+    days: [
+      {
+      "date": "2025-10-20",
+      "schedules": [
+        {
+          "date": "2025-10-20",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "노브레인",
+          "start": "15:00:00",
+          "end": "15:40:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "선우정아",
+          "start": "15:45:00",
+          "end": "16:25:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "No Party for Cao Dong (TW)",
+          "start": "16:30:00",
+          "end": "17:10:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "Bandit Bandit (FR)",
+          "start": "17:15:00",
+          "end": "17:55:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "혁오",
+          "start": "18:00:00",
+          "end": "18:40:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "태버 (Tabber)",
+          "start": "18:45:00",
+          "end": "19:25:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "Colonel Mustard & The Dijon 5 (UK)",
+          "start": "19:30:00",
+          "end": "20:10:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "잔나비",
+          "start": "20:15:00",
+          "end": "20:55:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "넉살 X 까데호",
+          "start": "21:00:00",
+          "end": "21:40:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "No Buses (JP)",
+          "start": "21:45:00",
+          "end": "22:25:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-20",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "Yaeji (DJ Set)",
+          "start": "22:40:00",
+          "end": "23:30:00",
+          "minutes": 50,
+          "img": null,
+          "note": null
+        }
+      ]
     },
+    {
+      "date": "2025-10-21",
+      "schedules": [
+        {
+          "date": "2025-10-21",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "장기하",
+          "start": "15:00:00",
+          "end": "15:40:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "Jambinai",
+          "start": "15:45:00",
+          "end": "16:25:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "설(SURL)",
+          "start": "16:30:00",
+          "end": "17:10:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "The fin. (JP)",
+          "start": "17:15:00",
+          "end": "17:55:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "새소년",
+          "start": "18:00:00",
+          "end": "18:40:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "The Volunteers",
+          "start": "18:45:00",
+          "end": "19:25:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "라이프 앤 타임",
+          "start": "19:30:00",
+          "end": "20:10:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "Peggy Gou",
+          "start": "20:15:00",
+          "end": "20:55:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "실리카겔",
+          "start": "21:00:00",
+          "end": "21:40:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "B-2",
+          "stageName": "Stage B",
+          "stageOrder": 2,
+          "artist": "이디오테잎",
+          "start": "21:45:00",
+          "end": "22:25:00",
+          "minutes": 40,
+          "img": null,
+          "note": null
+        },
+        {
+          "date": "2025-10-21",
+          "stageId": "A-1",
+          "stageName": "LAND STAGE (Stage A)",
+          "stageOrder": 1,
+          "artist": "250 (DJ Set)",
+          "start": "22:40:00",
+          "end": "23:30:00",
+          "minutes": 50,
+          "img": null,
+          "note": null
+        }
+      ]
+    }
+  ]
+  },
+  4: {
+    festivalId: 4,
+    festivalTitle: "DMZ 피스트레인 뮤직 페스티벌 2025",
+    days: [
+      {
+        date:"2025-12-20",
+        schedules:[
+          { date:"2025-12-20", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Busan Rock 1", start:"18:00:00", end:"18:40:00", minutes:40, img:null, note:null },
+          { date:"2025-12-20", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Busan Rock 2", start:"18:45:00", end:"19:25:00", minutes:40, img:null, note:null },
+          { date:"2025-12-20", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Busan Rock 3", start:"19:30:00", end:"20:10:00", minutes:40, img:null, note:null },
+        ]
+      }
+    ]
+  },
+  5: {
+    festivalId: 5,
+    festivalTitle: "2025 부산 락 페스티벌",
+    days: [
+      {
+        date:"2025-05-28",
+        schedules:[
+          { date:"2025-05-28", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Jazz 1", start:"17:00:00", end:"17:40:00", minutes:40, img:null, note:null },
+          { date:"2025-05-28", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Jazz 2", start:"17:45:00", end:"18:25:00", minutes:40, img:null, note:null },
+          { date:"2025-05-28", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Jazz 3", start:"18:30:00", end:"19:10:00", minutes:40, img:null, note:null },
+        ]
+      }
+    ]
+  },
+  6: {
+    festivalId: 6,
+    festivalTitle: "서울 재즈 페스티벌 2025",
+    days: [
+      {
+        date:"2025-08-15",
+        schedules:[
+          { date:"2025-08-15", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"Hongdae 1", start:"16:00:00", end:"16:40:00", minutes:40, img:null, note:null },
+          { date:"2025-08-15", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"Hongdae 2", start:"16:45:00", end:"17:25:00", minutes:40, img:null, note:null },
+          { date:"2025-08-15", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"Hongdae 3", start:"17:30:00", end:"18:10:00", minutes:40, img:null, note:null },
+        ]
+      }
+    ]
+  },
+  7: {
+    festivalId: 7,
+    festivalTitle: "페스티벌 이름",
+    days: [
+      {
+        date:"2025-09-10",
+        schedules:[
+          { date:"2025-09-10", stageId:"A-1", stageName:"Stage A", stageOrder:1, artist:"공연 이름", start:"15:00:00", end:"15:40:00", minutes:40, img:null, note:null },
+          { date:"2025-09-10", stageId:"B-2", stageName:"Stage B", stageOrder:2, artist:"공연 이름", start:"15:45:00", end:"16:25:00", minutes:40, img:null, note:null },
+          { date:"2025-09-10", stageId:"C-3", stageName:"Stage C", stageOrder:3, artist:"공연 이름", start:"16:30:00", end:"17:10:00", minutes:40, img:null, note:null },
+        ]
+      }
+    ]
+  }
 };
 
 type TimetableMode = 'customize' | 'my' | 'view'; 
-// ⭐️ 2. 데이터 로딩 함수 (외부로 분리하여 Refresh 시 재호출 가능하도록 함) ⭐️
+
+// ⭐️ 1. 데이터 로딩 함수 (외부로 분리, 깊은 복사 로직 포함) ⭐️
 async function fetchTimetableDetail(
     festivalId: string | undefined, 
     setCurrentDayIndex: (index: number) => void, 
@@ -58,10 +420,11 @@ async function fetchTimetableDetail(
     try {
         await new Promise(resolve => setTimeout(resolve, 500));
         const idNum = parseInt(festivalId);
+        // MockFestivalDetails[7]은 fallback 데이터입니다.
         const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7];
         
         if (baseData) {
-            // ⭐ 깊은 복사: 원본 Mock 데이터를 가져와 사용자 변경 사항을 덮어씁니다. ⭐
+            // ⭐ 핵심 로직: JSON을 이용한 깊은 복사 (Deep Copy) 수행 ⭐
             const dataToLoad = JSON.parse(JSON.stringify(baseData)) as FestivalDetailData;
             setDetailData(dataToLoad);
             
@@ -98,6 +461,8 @@ export default function TimetableDetailPage() {
 
     const allSchedules = useMemo(() => {
         if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
+        // isCustomized가 true인 스케줄만 필터링하는 등의 로직을 여기에 추가할 수 있습니다.
+        // 현재는 선택된 날짜의 모든 스케줄을 반환합니다.
         return detailData.days[currentDayIndex].schedules;
     }, [detailData, currentDayIndex]);
 
@@ -107,50 +472,50 @@ export default function TimetableDetailPage() {
             if (!stageMap[s.stageName]) stageMap[s.stageName] = [];
             stageMap[s.stageName].push(s);
         });
+        // StageOrder를 기반으로 스테이지 이름을 정렬하는 로직을 추가하면 좋습니다.
         const stageNames: Record<string, string> = {};
         Object.keys(stageMap).forEach((key, idx) => { stageNames[idx + ''] = key; });
         return { stageMap, stageNames };
     }, [allSchedules]);
 
+    // ⭐ 초기 로딩 (useEffect에서 외부 함수 호출로 통일) ⭐
     useEffect(() => {
-        if (!festivalId) { setIsLoading(false); return; }
-
-        async function fetchTimetableDetail() {
-            setIsLoading(true);
-            try {
-                await new Promise(resolve => setTimeout(resolve, 500));
-                const idNum = parseInt(festivalId);
-                const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7];
-                if (baseData) {
-                    setDetailData(baseData);
-                    if (baseData.days.length > 0) setCurrentDayIndex(0);
-                }
-            } catch (error) {
-                console.error(error);
-                setDetailData(null);
-            } finally { setIsLoading(false); }
-        }
-        fetchTimetableDetail();
+        fetchTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
     }, [festivalId, currentMode]);
 
     const handleGoBack = () => navigate(-1);
     const handleDownload = () => console.log("Download clicked");
-   // ⭐ Refresh 함수: 상태 초기화 및 데이터 재로드 ⭐
+   
+    // ⭐ Refresh 함수: 상태 초기화 및 데이터 재로드 로직 완성 ⭐
     const handleRefresh = () => {
-        console.log("Refresh button clicked! Resetting state and reloading data.");
+        console.log("Refresh button clicked! Resetting state and reloading data from Mock (Deep Copy).");
         
-        // 1. 화면 상태 초기화 (옵션)
+        // 1. 화면 상태 초기화 (날짜 선택을 리셋하여 로딩 상태를 확실히 하고, 드롭다운을 닫습니다.)
         setCurrentDayIndex(-1); 
         setIsDropdownOpen(false);
         
-        // 2. 데이터 로딩 함수를 직접 호출하여 데이터 재로드 (가장 중요)
+        // 2. 데이터 로딩 함수를 다시 호출하여 원본 Mock 데이터를 '깊은 복사'하여 재로드합니다.
+        // 이를 통해 사용자의 커스터마이징 이전 상태로 안전하게 돌아갑니다.
         fetchTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
     };
-    const handleDaySelect = (index: number) => { setCurrentDayIndex(index); setIsDropdownOpen(false); };
 
-    if (isLoading) return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;
-    if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex])
-        return <div className={timetableStyles.pageContainer}>정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
+    const handleDaySelect = (index: number) => { 
+        setCurrentDayIndex(index); 
+        setIsDropdownOpen(false); 
+    };
+
+    // 로딩 상태 처리
+    if (isLoading)
+        return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
+        
+    // 데이터 없음 상태 처리
+    if (!detailData || detailData.days.length === 0)
+        return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다.</div>;
+
+    // 데이터 정상 로드 후 현재 날짜가 선택되지 않았을 때 (초기 로드 중일 때)
+    if (currentDayIndex === -1 || !detailData.days[currentDayIndex])
+        return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
+
 
     const selectedDayData = detailData.days[currentDayIndex];
     const selectedDateFormatted = formatDayAndDayOfWeek(selectedDayData.date);

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,20 +1,13 @@
-// src/pages/timetable/TimetableDetailPage.tsx (최종 Hooks 수정 및 3개 Stage 고정)
-
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-// 경로에 맞게 이미지 import 경로는 수정해 주세요.
-import leftarrow from "../../assets/timetable/arrow-left.svg"
-import downarrow from "../../assets/timetable/arrow-down.svg"
-import download from "../../assets/timetable/download.svg"
-import refresh from "../../assets/timetable/refresh.svg"
+import leftarrow from "../../assets/timetable/arrow-left.svg";
+import downarrow from "../../assets/timetable/arrow-down.svg";
+import download from "../../assets/timetable/download.svg";
+import refresh from "../../assets/timetable/refresh.svg";
 
-import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
+import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
 import TimetableGrid from "../../components/timetable/TimetableGrid";
 
-
-// =========================================================
-// 1. 타입 정의 및 Mock 데이터 (길이가 길어 생략하며, 이전 코드를 유지하세요)
-// =========================================================
 export interface ScheduleItem { 
   date: string; stageId: string; stageName: string; stageOrder: number; 
   artist: string; start: string; end: string; minutes: number; 
@@ -23,7 +16,6 @@ export interface ScheduleItem {
 interface DayScheduleData { date: string; schedules: ScheduleItem[]; }
 interface FestivalDetailData { festivalId: number; festivalTitle: string; days: DayScheduleData[]; }
 
-// ⭐️ 날짜 형식 변환 유틸리티 함수 ⭐️
 const formatDayAndDayOfWeek = (dateString: string): string => {
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
     const date = new Date(dateString);
@@ -43,20 +35,15 @@ const MockFestivalDetails: Record<number, FestivalDetailData> = {
                 { date: "2025-12-20", stageId: "A-1", stageName: "LAND STAGE A", stageOrder: 1, artist: "구남과여라이딩스텔라", start: "17:00:00", end: "17:40:00", minutes: 40, img: null, note: null, isCustomized: true },
                 { date: "2025-12-20", stageId: "B-2", stageName: "LAND STAGE B", stageOrder: 2, artist: "사위", start: "15:45:00", end: "16:25:00", minutes: 40, img: null, note: null, isCustomized: true },
                 { date: "2025-12-20", stageId: "B-2", stageName: "LAND STAGE B", stageOrder: 2, artist: "초록불꽃소년단", start: "17:45:00", end: "18:25:00", minutes: 40, img: null, note: null, isCustomized: true },
-                { date: "2025-12-20", stageId: "C-3", stageName: "LAND STAGE C", stageOrder: 3, artist: "THE CHAIRS", start: "16:30:00", end: "17:10:00", minutes: 40, img: null, note: null, isCustomized: true },
-                { date: "2025-12-20", stageId: "C-3", stageName: "LAND STAGE C", stageOrder: 3, artist: "SUMIN", start: "18:30:00", end: "19:10:00", minutes: 40, img: null, note: null },
-                { date: "2025-12-20", stageId: "D-4", stageName: "LAND STAGE D", stageOrder: 4, artist: "New Band", start: "19:30:00", end: "20:30:00", minutes: 60, img: null, note: null },
+                { date: "2025-12-20", stageId: "C-3", stageName: "LAND STAGE C", stageOrder: 3, artist: "THE CHAIRS", start: "16:30:00", end: "17:10:00", minutes: 40, img: null, note: null },
             ] 
         }],
     },
-    // ... (다른 Mock 데이터 유지) ...
 };
+
 type TimetableMode = 'customize' | 'my' | 'view'; 
 
-
 export default function TimetableDetailPage() {
-    
-    // ⭐️ 1. 모든 Hooks는 함수 컴포넌트의 최상단에 위치합니다. ⭐️
     const navigate = useNavigate();
     const location = useLocation();
     const { id: festivalId } = useParams<{ id: string }>(); 
@@ -66,195 +53,113 @@ export default function TimetableDetailPage() {
     const [currentDayIndex, setCurrentDayIndex] = useState(-1);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-
     const currentMode: TimetableMode = useMemo(() => {
         if (location.pathname.includes('/my/')) return 'my';
         if (location.pathname.includes('/customize/')) return 'customize';
         return 'view'; 
     }, [location.pathname]);
 
-    
-    // ⭐️ 2. 데이터 추출 및 필터링 useMemo도 Early Return 이전에 선언 ⭐️
     const allSchedules = useMemo(() => {
-        // detailData나 days가 없을 경우 안전하게 빈 배열 반환
-        if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) {
-            return [];
-        }
+        if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
         return detailData.days[currentDayIndex].schedules;
     }, [detailData, currentDayIndex]);
-    
-    // ⭐️ Stage 3개 고정 필터링 로직 ⭐️
-    const schedulesByStage = useMemo(() => {
-        const stage1Schedules = allSchedules.filter(s => s.stageOrder === 1);
-        const stage2Schedules = allSchedules.filter(s => s.stageOrder === 2);
-        const stage3Schedules = allSchedules.filter(s => s.stageOrder === 3);
 
-        const stageNames = {
-            1: stage1Schedules[0]?.stageName || "Stage 1",
-            2: stage2Schedules[0]?.stageName || "Stage 2",
-            3: stage3Schedules[0]?.stageName || "Stage 3",
-        };
-        
-        return {
-            stage1: stage1Schedules,
-            stage2: stage2Schedules,
-            stage3: stage3Schedules,
-            stageNames: stageNames,
-        };
+    const schedulesByStage = useMemo(() => {
+        const stageMap: Record<string, ScheduleItem[]> = {};
+        allSchedules.forEach(s => {
+            if (!stageMap[s.stageName]) stageMap[s.stageName] = [];
+            stageMap[s.stageName].push(s);
+        });
+        const stageNames: Record<string, string> = {};
+        Object.keys(stageMap).forEach((key, idx) => { stageNames[idx + ''] = key; });
+        return { stageMap, stageNames };
     }, [allSchedules]);
 
-
-    // --- useEffect, 핸들러 (이전 코드 유지) ---
     useEffect(() => {
-        if (!festivalId) { 
-            setIsLoading(false);
-            return;
-        }
+        if (!festivalId) { setIsLoading(false); return; }
 
         async function fetchTimetableDetail() {
             setIsLoading(true);
             try {
-                await new Promise(resolve => setTimeout(resolve, 500)); 
-                
-                let dataToLoad: FestivalDetailData | null = null;
-                const idNum = parseInt(festivalId!); 
-                const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7]; 
-                
+                await new Promise(resolve => setTimeout(resolve, 500));
+                const idNum = parseInt(festivalId);
+                const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7];
                 if (baseData) {
-                    dataToLoad = baseData;
-                    if (baseData.days.length > 0) {
-                        setCurrentDayIndex(0); 
-                    }
+                    setDetailData(baseData);
+                    if (baseData.days.length > 0) setCurrentDayIndex(0);
                 }
-                setDetailData(dataToLoad); 
-
             } catch (error) {
-                console.error(`상세 타임테이블 로드 오류:`, error);
-                setDetailData(null); 
-            } finally {
-                setIsLoading(false);
-            }
+                console.error(error);
+                setDetailData(null);
+            } finally { setIsLoading(false); }
         }
         fetchTimetableDetail();
-    }, [festivalId, currentMode]); 
+    }, [festivalId, currentMode]);
 
-    const handleGoBack = () => { navigate(-1); };
-    const handleDownload = () => { console.log("Download button clicked!"); };
-    const handleRefresh = () => { console.log("Refresh/Reset button clicked!"); };
-    const handleDaySelect = (index: number) => {
-        setCurrentDayIndex(index);
-        setIsDropdownOpen(false);
-    };
+    const handleGoBack = () => navigate(-1);
+    const handleDownload = () => console.log("Download clicked");
+    const handleRefresh = () => console.log("Refresh clicked");
+    const handleDaySelect = (index: number) => { setCurrentDayIndex(index); setIsDropdownOpen(false); };
 
+    if (isLoading) return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;
+    if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex])
+        return <div className={timetableStyles.pageContainer}>정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
 
-    // --- Early Return ---
-    if (isLoading) {
-        return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;
-    }
-
-    if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) {
-        return <div className={timetableStyles.pageContainer}>
-            {detailData ? "날짜를 선택해 주세요." : `요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: ${festivalId})`}
-        </div>;
-    }
-    
     const selectedDayData = detailData.days[currentDayIndex];
-    
     const selectedDateFormatted = formatDayAndDayOfWeek(selectedDayData.date);
     const toggleButtonText = isDropdownOpen ? "날짜 선택" : selectedDateFormatted;
     const toggleClass = `${timetableStyles.dayDropdownToggle} ${isDropdownOpen ? timetableStyles.open : ''}`;
     const textClass = currentDayIndex !== -1 && !isDropdownOpen ? timetableStyles.fontSet : timetableStyles.placeholderText;
 
-
-    // --- 메인 UI 렌더링 ---
     return (
         <div className={timetableStyles.pageContainer}>
-            
             <header className={timetableStyles.header}>
-                <button 
-                    className={timetableStyles.backButton}
-                    onClick={handleGoBack}
-                >
+                <button className={timetableStyles.backButton} onClick={handleGoBack}>
                     <img src={leftarrow} alt="뒤로 가기" />
                 </button>
-                
-                <h1 className={timetableStyles.pageTitle}>
-                    {detailData.festivalTitle} 
-                </h1>
+                <h1 className={timetableStyles.pageTitle}>{detailData.festivalTitle}</h1>
                 <div className={timetableStyles.emptyBox}></div>
             </header>
 
             <main className={timetableStyles.mainContent}>
-                
-               {/* 1. 컨트롤 바 (드롭다운 + 다운로드/리프레시 버튼) */}
                 {detailData.days.length > 0 && (
-                     <div className={timetableStyles.timetableControlBar}>
+                    <div className={timetableStyles.timetableControlBar}>
                         <div className={timetableStyles.dropdownWrapper}>
                             <button className={toggleClass} onClick={() => setIsDropdownOpen(prev => !prev)}>
                                 <span className={textClass}>{toggleButtonText}</span>
-                                <img 
-                                    src={downarrow} 
-                                    alt="드롭다운 화살표"
-                                    className={isDropdownOpen ? timetableStyles.arrowOpen : timetableStyles.arrowClosed}
-                                />
+                                <img src={downarrow} alt="드롭다운 화살표" className={isDropdownOpen ? timetableStyles.arrowOpen : timetableStyles.arrowClosed}/>
                             </button>
-
                             {isDropdownOpen && (
                                 <ul className={timetableStyles.dayDropdownList}>
                                     {detailData.days.map((day, index) => (
                                         <li key={index} className={timetableStyles.dayDropdownItem}>
-                                            <button
-                                                className={`${timetableStyles.dayDropdownOption} ${
-                                                    index === currentDayIndex ? timetableStyles.active : ''
-                                                }`}
-                                                onClick={() => handleDaySelect(index)}
-                                            >
-                                                <span 
-                                                    className={`${timetableStyles.selectedDateTextWrapper} ${
-                                                        index === currentDayIndex ? timetableStyles.dateTextActive : ''
-                                                    }`}
-                                                >
-                                                    {formatDayAndDayOfWeek(day.date)}
-                                                </span>
+                                            <button className={`${timetableStyles.dayDropdownOption} ${index===currentDayIndex? timetableStyles.active:''}`} onClick={()=>handleDaySelect(index)}>
+                                                {formatDayAndDayOfWeek(day.date)}
                                             </button>
                                         </li>
                                     ))}
                                 </ul>
                             )}
                         </div>
-                        
                         <div className={timetableStyles.actionButtonWrapper}>
-                            <button className={timetableStyles.actionButton} onClick={handleDownload}>
-                                <img src={download} alt="다운로드" />
-                            </button>
-                            <button className={timetableStyles.actionButton} onClick={handleRefresh}>
-                                <img src={refresh} alt="되돌리기" />
-                            </button>
+                            <button className={timetableStyles.actionButton} onClick={handleDownload}><img src={download} alt="다운로드"/></button>
+                            <button className={timetableStyles.actionButton} onClick={handleRefresh}><img src={refresh} alt="되돌리기"/></button>
                         </div>
-
                     </div>
                 )}
-                
-                {/* ⭐️ 2. 타임테이블 영역 ⭐️ */}
-                {currentDayIndex !== -1 && (
-                    <div className={timetableStyles.scheduleArea}>
-                        
-                        
-                        
-                        {/* Stage 3개 고정 Props 전달 */}
-                        <TimetableGrid 
-                            stage1Schedules={schedulesByStage.stage1}
-                            stage2Schedules={schedulesByStage.stage2}
-                            stage3Schedules={schedulesByStage.stage3}
-                            stageNames={schedulesByStage.stageNames}
-                            allSchedules={allSchedules}
-                            mode={currentMode}
-                        />
 
-                    </div>
+                {currentDayIndex !== -1 && (
+                <div className={timetableStyles.timetableScrollWrapper}><div className={timetableStyles.scheduleArea}>
+                        <TimetableGrid 
+                            stageMap={schedulesByStage.stageMap} 
+                            stageNames={schedulesByStage.stageNames} 
+                            allSchedules={allSchedules} 
+                            mode={currentMode} 
+                        />
+                    </div></div>
+                    
                 )}
             </main>
-
         </div>
     );
 }

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -537,7 +537,7 @@ export default function TimetableDetailPage() {
                 {detailData.days.length > 0 && (
                     <div className={timetableStyles.timetableControlBar}>
                         <div className={timetableStyles.dropdownWrapper}>
-                            <button className={toggleClass} onClick={() => setIsDropdownOpen(prev => !prev)}>
+                            <button className={toggleClass} onClick={() => {if (detailData.days.length <= 1) return;setIsDropdownOpen(prev => !prev)}}>
                                 <span className={textClass}>{toggleButtonText}</span>
                                 <img src={downarrow} alt="드롭다운 화살표" className={isDropdownOpen ? timetableStyles.arrowOpen : timetableStyles.arrowClosed}/>
                             </button>
@@ -546,7 +546,8 @@ export default function TimetableDetailPage() {
                                     {detailData.days.map((day, index) => (
                                         <li key={index} className={timetableStyles.dayDropdownItem}>
                                             <button className={`${timetableStyles.dayDropdownOption} ${index===currentDayIndex? timetableStyles.active:''}`} onClick={()=>handleDaySelect(index)}>
-                                                {formatDayAndDayOfWeek(day.date)}
+                                                <div className={timetableStyles.textSpace}>{formatDayAndDayOfWeek(day.date)}</div>
+                                                
                                             </button>
                                         </li>
                                     ))}

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,8 +1,9 @@
-// src/pages/timetable/TimetableDetailPage.tsx
-
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import leftarrow from "../../assets/timetable/arrow-left.svg"
+import downarrow from "../../assets/timetable/arrow-down.svg" // downarrow 이미지 import 필요
+import download from "../../assets/timetable/download.svg"
+import refresh from "../../assets/timetable/refresh.svg"
 
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
 
@@ -11,18 +12,15 @@ import timetableStyles from "../../css/pages/timetable/timetabledetail.module.cs
 interface FestivalDetailData {
   festivalId: number;
   festivalTitle: string;
-  // date 속성은 'YYYY-MM-DD' 형식의 문자열로 가정합니다.
   days: { date: string; stages: { stageName: string; }[] }[]; 
 }
 
-// ⭐️ 날짜 형식 변환 유틸리티 함수 추가 ⭐️
+// ⭐️ 날짜 형식 변환 유틸리티 함수 ⭐️
 const formatDayAndDayOfWeek = (dateString: string): string => {
-    // 요일 배열 (한국어)
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
 
     const date = new Date(dateString);
 
-    // Date 객체 생성 시 유효하지 않은 날짜 포맷일 수 있으므로 유효성 검사 추가
     if (isNaN(date.getTime())) {
         console.error("Invalid date format:", dateString);
         return dateString; 
@@ -35,13 +33,12 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
     return `${month}.${day}(${dayOfWeek})`;
 };
 
-// ⭐️ 2. 임시 Mock 데이터를 YYYY-MM-DD 형식으로 수정 (함수 적용을 위해) ⭐️
+// ⭐️ 2. 임시 Mock 데이터를 YYYY-MM-DD 형식으로 가정하여 수정 ⭐️
 const MockFestivalDetails: Record<number, FestivalDetailData> = {
     1: {
         festivalId: 1, 
         festivalTitle: "그랜드 민트 페스티벌 2025",
         days: [
-            // 형식 수정: YYYY-MM-DD
             { date: "2025-12-20", stages: [{ stageName: "Mint Breeze Stage" }] }, 
             { date: "2025-12-21", stages: [{ stageName: "Loving Forest Garden" }] }
         ],
@@ -83,7 +80,9 @@ export default function TimetableDetailPage() {
     const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     
-    const [currentDayIndex, setCurrentDayIndex] = useState(0);
+    const [currentDayIndex, setCurrentDayIndex] = useState(-1); // 초기값 -1
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
 
     const currentMode: TimetableMode = useMemo(() => {
         if (location.pathname.includes('/my/')) return 'my';
@@ -94,7 +93,26 @@ export default function TimetableDetailPage() {
     const handleGoBack = () => {
         navigate(-1); 
     };
+    
+    // ⭐️ 다운로드 버튼 핸들러 ⭐️
+    const handleDownload = () => {
+        console.log("Download button clicked!");
+        // 여기에 타임테이블 이미지 저장 로직 구현
+    };
+    
+    // ⭐️ 되돌리기/리프레시 버튼 핸들러 ⭐️
+    const handleRefresh = () => {
+        console.log("Refresh/Reset button clicked!");
+        // 여기에 커스텀 타임테이블 초기화 또는 되돌리기 로직 구현
+    };
+    
+    // ⭐️ 날짜 선택 핸들러 ⭐️
+    const handleDaySelect = (index: number) => {
+        setCurrentDayIndex(index);
+        setIsDropdownOpen(false); // 선택 후 드롭다운 닫기
+    };
 
+    // 데이터 로딩 (API 호출 시뮬레이션)
     useEffect(() => {
         if (!festivalId) { 
             setIsLoading(false);
@@ -111,21 +129,16 @@ export default function TimetableDetailPage() {
                 const baseData = MockFestivalDetails[idNum];
 
                 if (baseData) {
-                    if (currentMode === 'customize') {
-                        dataToLoad = baseData;
-                    } else if (currentMode === 'my') {
-                        dataToLoad = { 
-                            ...baseData,
-                            festivalTitle: baseData.festivalTitle + " (내 커스텀)"
-                        }; 
-                    }
+                    dataToLoad = baseData;
+                    // 데이터 로드 완료 후, 첫 번째 날짜(인덱스 0)를 기본 선택하도록 설정
                     setCurrentDayIndex(0); 
+                    setIsDropdownOpen(false); 
                 }
                 
                 setDetailData(dataToLoad); 
 
             } catch (error) {
-                console.error(`[${currentMode} Mode] 상세 타임테이블 로드 오류:`, error);
+                console.error(`상세 타임테이블 로드 오류:`, error);
                 setDetailData(null); 
             } finally {
                 setIsLoading(false);
@@ -145,8 +158,26 @@ export default function TimetableDetailPage() {
         return <div className={timetableStyles.pageContainer}>요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
     }
 
-    // 현재 선택된 날짜의 데이터
+    // 현재 선택된 날짜 데이터 준비
     const selectedDayData = detailData.days[currentDayIndex];
+    
+    // 현재 선택된 날짜를 포맷팅. (currentDayIndex가 -1이 아닐 경우만 사용)
+    const selectedDateFormatted = currentDayIndex !== -1 
+        ? formatDayAndDayOfWeek(selectedDayData.date)
+        : "날짜 선택";
+
+    // ⭐️ 토글 버튼에 표시될 최종 텍스트 결정 ⭐️
+    const toggleButtonText = isDropdownOpen
+        ? "날짜 선택" // 드롭다운이 열리면 '날짜 선택' 표시
+        : selectedDateFormatted; // 닫혀 있으면 선택된 날짜 표시
+
+    // ⭐️ 토글 버튼 클래스 (open/close 상태에 따라 테두리 색상 변경 및 화살표 회전) ⭐️
+    const toggleClass = `${timetableStyles.dayDropdownToggle} ${isDropdownOpen ? timetableStyles.open : ''}`;
+    
+    // ⭐️ 텍스트 클래스 (선택된 날짜가 있을 때만 보라색 fontSet 적용) ⭐️
+    const textClass = currentDayIndex !== -1 && !isDropdownOpen
+        ? timetableStyles.fontSet
+        : timetableStyles.placeholderText;
 
     // --- 메인 UI 렌더링 ---
     return (
@@ -168,50 +199,86 @@ export default function TimetableDetailPage() {
 
             <main className={timetableStyles.mainContent}>
                 
-               {/* ⭐️ 1. 날짜 드롭다운 UI ⭐️ */}
+               {/* ⭐️ 1. 컨트롤 바 (드롭다운 + 다운로드/리프레시 버튼) ⭐️ */}
                 {detailData.days.length > 0 && (
-                    <div className={timetableStyles.dayDropdownContainer}>
+                    <div className={timetableStyles.timetableControlBar}>
                         
-                        {/* ⚠️ 레이블(label)은 접근성을 위해 유지하는 것을 권장합니다. */}
-                        {/* <label htmlFor="day-selector" className={timetableStyles.dayDropdownLabel}>날짜 선택</label> */}
+                        {/* 1-1. 드롭다운 래퍼: absolute list의 기준점 */}
+                        <div className={timetableStyles.dropdownWrapper}>
+                            <button
+                                className={toggleClass}
+                                onClick={() => setIsDropdownOpen(prev => !prev)}
+                            >
+                                <span className={textClass}>
+                                    {toggleButtonText}
+                                </span>
+                                <img 
+                                    src={downarrow} 
+                                    alt="드롭다운 화살표"
+                                    className={isDropdownOpen ? timetableStyles.arrowOpen : timetableStyles.arrowClosed}
+                                />
+                            </button>
 
-                        <select
-                            id="day-selector"
-                            className={timetableStyles.dayDropdown}
-                            value={currentDayIndex}
-                            onChange={(e) => setCurrentDayIndex(parseInt(e.target.value))}
-                        >
-                            {detailData.days.map((day, index) => (
-                                <option
-                                    key={index}
-                                    value={index} 
-                                >
-                                    {/* ⭐️ 날짜 형식 변환 함수 적용 ⭐️ */}
-                                    {formatDayAndDayOfWeek(day.date)}
-                                </option>
-                            ))}
-                        </select>
+                            {/* 2. 날짜 목록 (isDropdownOpen이 true일 때만 표시) */}
+                            {isDropdownOpen && (
+                                <ul className={timetableStyles.dayDropdownList}>
+                                    {detailData.days.map((day, index) => (
+                                        <li 
+                                            key={index}
+                                            className={timetableStyles.dayDropdownItem}
+                                        >
+                                            <button
+                                                className={`${timetableStyles.dayDropdownOption} ${
+                                                    index === currentDayIndex ? timetableStyles.active : ''
+                                                }`}
+                                                onClick={() => handleDaySelect(index)}
+                                            >
+                                                {/* ⭐️ 수정: 텍스트를 <span>으로 감싸서 별도의 박스 스타일을 적용할 수 있도록 함 ⭐️ */}
+                                                <span 
+                                                    className={`${timetableStyles.selectedDateTextWrapper} ${
+                                                        index === currentDayIndex ? timetableStyles.dateTextActive : ''
+                                                    }`}
+                                                >
+                                                    {formatDayAndDayOfWeek(day.date)}
+                                                </span>
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                        
+                        {/* 1-2. 액션 버튼 래퍼 */}
+                        <div className={timetableStyles.actionButtonWrapper}>
+                            <button className={timetableStyles.actionButton} onClick={handleDownload}>
+                                <img src={download} alt="다운로드" />
+                            </button>
+                            <button className={timetableStyles.actionButton} onClick={handleRefresh}>
+                                <img src={refresh} alt="되돌리기" />
+                            </button>
+                        </div>
 
                     </div>
                 )}
                 
-                {/* ⭐️ 2. 선택된 날짜의 스테이지/일정 영역 ⭐️ */}
-                <div className={timetableStyles.scheduleArea}>
-                    
-                    {/* ⭐️ 제목에도 변환된 날짜 적용 ⭐️ */}
-                    <h3>{formatDayAndDayOfWeek(selectedDayData.date)} 일정</h3>
-                    
-                    {/* TODO: 여기에 스테이지 필터와 실제 타임테이블 목록이 들어갑니다. */}
-                    <div style={{ marginTop: '10px', padding: '10px', border: '1px solid #ccc' }}>
-                        <p>선택된 날짜의 스테이지 수: {selectedDayData.stages.length}</p>
-                        <ul>
-                            {selectedDayData.stages.map((stage, index) => (
-                                <li key={index}>{stage.stageName}</li>
-                            ))}
-                        </ul>
-                    </div>
+                {/* ⭐️ 2. 선택된 날짜의 스테이지/일정 영역 (날짜가 선택되었을 때만 표시) ⭐️ */}
+                {currentDayIndex !== -1 && (
+                    <div className={timetableStyles.scheduleArea}>
+                        
+                        <h3>{formatDayAndDayOfWeek(selectedDayData.date)} 일정</h3>
+                        
+                        {/* TODO: 여기에 스테이지 필터와 실제 타임테이블 목록이 들어갑니다. */}
+                        <div style={{ marginTop: '10px', padding: '10px', border: '1px solid #ccc' }}>
+                            <p>선택된 날짜의 스테이지 수: {selectedDayData.stages.length}</p>
+                            <ul>
+                                {selectedDayData.stages.map((stage, index) => (
+                                    <li key={index}>{stage.stageName}</li>
+                                ))}
+                            </ul>
+                        </div>
 
-                </div>
+                    </div>
+                )}
             </main>
 
         </div>

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 버전: 시간 타입 유연성 확보 및 상태 관리)
+// src/pages/timetable/TimetableDetailPage.tsx
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -7,11 +7,11 @@ import leftarrow from "../../assets/timetable/arrow-left.svg";
 import downarrow from "../../assets/timetable/arrow-down.svg";
 import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
-import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; // 경로 확인 필요
+import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css";
 import TimetableGrid from "../../components/timetable/TimetableGrid"; 
-import api from "../../api/api"; 
+import api from "../../api/api"; // Axios 인스턴스
 
-// ⭐️ Kopis API 응답 타입 (start/end를 객체 또는 문자열로 받도록 수정) ⭐️
+// ⭐️ Kopis API 응답 타입 ⭐️
 export interface KopisFestivalItem {
   id: number; 
   prfnm: string; 
@@ -22,7 +22,6 @@ export interface KopisFestivalItem {
   slots: { 
     date: string; stageId: string; stageName: string; stageOrder: number; 
     artist: string; 
-    // ⭐️ start와 end 필드를 객체이거나 문자열일 수 있도록 정의 ⭐️
     start: string | { hour: number; minute: number; second: number; nano: number; }; 
     end: string | { hour: number; minute: number; second: number; nano: number; }; 
     minutes: number; img: string | null; note: string | null; 
@@ -40,8 +39,7 @@ interface FestivalDetailData {
     days: DayScheduleData[]; 
 }
 
-// ⭐️ (추가) ⭐️ 스케줄 아이템의 고유 키를 생성하는 헬퍼 함수
-// date, stageId, artist, start 시간을 조합하여 고유한 문자열을 만듭니다.
+// ⭐️ 스케줄 아이템의 고유 키를 생성하는 헬퍼 함수
 const createScheduleKey = (s: ScheduleItem) => `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
 
 const formatDayAndDayOfWeek = (dateString: string): string => {
@@ -75,48 +73,31 @@ async function fetchAndProcessTimetableDetail(
     try {
         const response = await api.get(`/kopis/performances/festivals?festivalId=${idNum}`); 
         
-        console.log("📌 API 전체 응답:", response.data);
-
         const rawData = response.data.data || response.data;
         const apiData: KopisFestivalItem | undefined = Array.isArray(rawData)
-            ? rawData.find(f => f.id === idNum) || rawData[0] // 배열일 경우 첫 번째 요소도 고려
+            ? rawData.find(f => f.id === idNum) || rawData[0] 
             : rawData;
 
-        if (!apiData) {
-            console.error(`⚠️ festivalId ${festivalId}에 해당하는 데이터가 없습니다.`);
+        if (!apiData || !apiData.prfnm || (apiData.slots || []).length === 0) {
+            console.error(`⚠️ festivalId ${festivalId}에 해당하는 데이터가 없거나 필수 필드가 누락되었습니다.`);
             setDetailData(null);
             setIsLoading(false);
             return null;
         }
 
-        const slots = apiData.slots || [];
-
-        if (!apiData.prfnm || slots.length === 0) { 
-             console.error("⚠️ 필수 필드 누락 또는 slots 없음");
-             setDetailData(null);
-             setIsLoading(false);
-             return null;
-        }
-
         const schedulesByDateMap: Record<string, ScheduleItem[]> = {};
 
-        slots.forEach(slot => {
+        apiData.slots.forEach(slot => {
             const dateString = slot.date;
             
-            // ⭐️⭐️ 시간 포맷팅 로직 수정: 문자열과 객체 모두 처리 ⭐️⭐️
             let startString = "00:00:00";
             let endString = "00:00:00";
 
-            // 1. start/end가 이미 문자열인 경우 (Main Page에서 본 유효한 형식)
             if (typeof slot.start === 'string') {
                 startString = slot.start;
-            } 
-            // 2. start/end가 객체인 경우 (Detail Page의 인터페이스 형식)
-            else if (slot.start && typeof slot.start === 'object') {
+            } else if (slot.start && typeof slot.start === 'object') {
                 const startHour = slot.start.hour ?? 0;
                 const startMinute = slot.start.minute ?? 0;
-                
-                // **주의:** 여기서 hour/minute이 0이라면 "00:00:00"이 되며, 이는 서버 데이터 문제
                 startString = `${startHour.toString().padStart(2,'0')}:${startMinute.toString().padStart(2,'0')}:00`;
             }
             
@@ -128,15 +109,14 @@ async function fetchAndProcessTimetableDetail(
                 endString = `${endHour.toString().padStart(2,'0')}:${endMinute.toString().padStart(2,'0')}:00`;
             }
 
-
             const scheduleItem: ScheduleItem = {
                 date: slot.date,
                 stageId: slot.stageId,
                 stageName: slot.stageName,
                 stageOrder: slot.stageOrder,
                 artist: slot.artist,
-                start: startString, // 수정된 문자열 사용
-                end: endString,     // 수정된 문자열 사용
+                start: startString, 
+                end: endString,     
                 minutes: slot.minutes,
                 img: slot.img || null,
                 note: slot.note || null,
@@ -147,14 +127,9 @@ async function fetchAndProcessTimetableDetail(
             schedulesByDateMap[dateString].push(scheduleItem);
         });
 
-        console.log("📌 모든 ScheduleItem:", Object.values(schedulesByDateMap).flat().slice(0, 5)); // 상위 5개만 로그 출력
-
         const processedDays: DayScheduleData[] = Object.keys(schedulesByDateMap)
             .sort()
-            .map(date => ({
-                date,
-                schedules: schedulesByDateMap[date]
-            }));
+            .map(date => ({ date, schedules: schedulesByDateMap[date] }));
 
         processedData = {
             festivalId: idNum,
@@ -162,10 +137,7 @@ async function fetchAndProcessTimetableDetail(
             days: processedDays
         };
         
-        console.log("✅ processedData:", processedData);
-
         setDetailData(processedData);
-            
         if (processedData.days.length > 0) setCurrentDayIndex(0);
 
     } catch (error) {
@@ -188,38 +160,29 @@ export default function TimetableDetailPage() {
     const [currentDayIndex, setCurrentDayIndex] = useState(-1);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-    // ⭐️ (추가) ⭐️ 선택된 스케줄을 추적하는 상태 (Set 사용)
     const [activeScheduleKeys, setActiveScheduleKeys] = useState<Set<string>>(new Set());
     
-    // ⭐️ (수정/추가) ⭐️ 스케줄을 클릭했을 때 상태를 토글하는 함수
     const handleScheduleToggle = (schedule: ScheduleItem) => {
         const key = createScheduleKey(schedule);
         
-        // ⭐️ (수정) ⭐️ const로 명확하게 선언하여 스코프 오류를 해결합니다.
-        // 현재 상태를 기준으로 클릭 후의 예상 상태를 미리 계산합니다.
         const newStateIsActive = !activeScheduleKeys.has(key); 
 
         setActiveScheduleKeys(prev => {
             const newSet = new Set(prev);
             if (newSet.has(key)) {
-                newSet.delete(key); // 이미 선택되었으면 제거 (inverted: false)
+                newSet.delete(key); 
             } else {
-                newSet.add(key); // 선택되지 않았으면 추가 (inverted: true)
+                newSet.add(key); 
             }
             return newSet;
         });
         
-        // ⭐️ (수정) 콘솔 로깅으로 inverted 여부 확인 ⭐️
         console.log("--- Schedule Toggled ---");
         console.log("Date:", schedule.date);
         console.log("Artist:", schedule.artist);
         console.log("Stage Order:", schedule.stageOrder);
-        // 계산된 로컬 변수 newStateIsActive를 사용합니다.
-        console.log("Inverted/Selected (New State):", newStateIsActive);
+        console.log("Inverted/Selected (New State):", newStateIsActive); 
         console.log("------------------------");
-        
-        // ⭐️ (추가) ⭐️ 상태 변경 후 페이로드 생성 함수를 호출할 수 있습니다.
-        // 예를 들어: createAndSendInvertedSlotsPayload();
     };
 
     const currentMode: TimetableMode = useMemo(() => {
@@ -228,33 +191,38 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
     
-    // ⭐️ (추가) ⭐️ 서버 전송 페이로드를 생성하는 함수 (나중에 버튼에 연결)
-    const createInvertedSlotsPayload = (): { mt20id: string; invertedSlots: any[] } | null => {
-        if (!detailData || currentDayIndex === -1) return null;
+    // ⭐️ (수정) ⭐️ 페이로드 생성 시 선택 여부(hasSelections)도 함께 반환하도록 수정
+    const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
+        if (!detailData || currentDayIndex === -1) return { payload: null, hasSelections: false };
         
         const currentDaySchedules = detailData.days[currentDayIndex]?.schedules || [];
+        let hasSelections = false;
 
-        // 현재 날짜의 모든 스케줄을 순회하며 inverted 여부를 결정합니다.
         const invertedSlots = currentDaySchedules.map(schedule => {
             const key = createScheduleKey(schedule);
-            const isInverted = activeScheduleKeys.has(key); // Set에 있으면 true (선택됨)
+            const isInverted = activeScheduleKeys.has(key); 
+            
+            if (isInverted) {
+                hasSelections = true;
+            }
             
             return {
                 date: schedule.date,
                 stageOrder: schedule.stageOrder,
                 artist: schedule.artist,
-                // ⭐️ 활성화 상태를 inverted 필드 값으로 사용 ⭐️
                 inverted: isInverted 
             };
         });
 
+        // ⚠️ 이 mt20id는 실제 사용자 ID 또는 타임테이블 고유 ID로 대체되어야 합니다.
+        const TEMP_MT20ID = "TEMP_USER_OR_TABLE_ID"; 
+
         const payload = {
-            mt20id: "TEMP_USER_ID_OR_MT_ID", // 실제 사용자 ID나 테이블 ID로 대체
+            mt20id: TEMP_MT20ID, 
             invertedSlots: invertedSlots
         };
         
-        console.log("🚀 서버 전송 페이로드 미리보기:", payload);
-        return payload;
+        return { payload, hasSelections };
     };
 
 
@@ -270,7 +238,6 @@ export default function TimetableDetailPage() {
             stageMap[s.stageName].push(s);
         });
         
-        // 무대 순서에 따라 정렬 (TimetableGrid에서 사용됨)
         const uniqueStages = Array.from(new Set(allSchedules.map(s => JSON.stringify({ name: s.stageName, order: s.stageOrder }))));
         const sortedStages = uniqueStages.map(s => JSON.parse(s)).sort((a, b) => a.order - b.order);
         const stageNames: Record<string, string> = {}; 
@@ -280,7 +247,6 @@ export default function TimetableDetailPage() {
     }, [allSchedules]);
 
     useEffect(() => {
-        console.log("🎯 현재 festivalId:", festivalId);
         if (festivalId) {
             fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
         } else {
@@ -288,16 +254,50 @@ export default function TimetableDetailPage() {
              setDetailData(null); 
         }
     }, [festivalId]);
-
-
-    const handleGoBack = () => navigate(-1);
     
-    // ⭐️ (수정) ⭐️ 다운로드 버튼을 서버 저장 버튼으로 가정하고 페이로드 생성 로직 연결
-    const handleSaveTimetable = () => {
-        const payload = createInvertedSlotsPayload();
-        if (payload) {
-            console.log("Saving timetable to server...", payload);
-            // 여기에 api.put('/mytimetable', payload) 같은 서버 저장 로직 추가
+    // ⭐️ (추가) ⭐️ 핵심 저장 로직. 성공/건너뛰면 true, 실패하면 false 반환
+    const saveTimetableData = async (): Promise<boolean> => { 
+        const { payload, hasSelections } = getPayloadAndCheckSelection();
+
+        if (!payload) return true;
+        
+        // ⭐️ 조건: 선택된 스케줄이 없으면 서버에 저장 요청을 건너뜁니다. ⭐️
+        if (!hasSelections) {
+            console.log("ℹ️ 선택된 스케줄이 없어 서버에 저장 요청을 건너뜁니다.");
+            return true; 
+        }
+
+        const mt20id = payload.mt20id;
+        const API_ENDPOINT = `/festivals/${mt20id}/custom-slots`; 
+        const HTTP_METHOD = 'PUT'; 
+
+        console.log(`💾 Final Payload Ready for ${HTTP_METHOD} to ${API_ENDPOINT}:`, payload);
+
+        try {
+            const response = await api.put(API_ENDPOINT, payload); 
+
+            console.log(`✅ 타임테이블 저장 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, response.data);
+            alert("나의 타임테이블이 성공적으로 서버에 저장되었습니다!");
+            return true;
+
+        } catch (error) {
+            const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
+            console.error(`❌ 타임테이블 저장 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error);
+            alert(`타임테이블 저장 중 오류가 발생했습니다: ${errorMessage}`);
+            return false;
+        }
+    };
+    
+    // ⭐️ (수정) ⭐️ 뒤로 가기 버튼 클릭 시 저장 로직 실행 후 이동
+    const handleGoBack = async () => {
+        const saveSuccessful = await saveTimetableData();
+
+        // 저장에 성공했거나 (true), 데이터가 없어 건너뛰었을 경우 (true), 뒤로 이동
+        if (saveSuccessful) {
+            navigate(-1);
+        } else {
+            // 저장 실패 시 (false) 경고창을 띄우고 페이지에 머무름
+            console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
         }
     };
     
@@ -305,7 +305,6 @@ export default function TimetableDetailPage() {
         console.log("🔄 Refreshing data from API.");
         setCurrentDayIndex(-1); 
         setIsDropdownOpen(false);
-        // ⭐️ (추가) ⭐️ 새로고침 시 선택 상태도 초기화
         setActiveScheduleKeys(new Set()); 
         if (festivalId) fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
         else { setDetailData(null); setIsLoading(false); }
@@ -316,7 +315,6 @@ export default function TimetableDetailPage() {
         setIsDropdownOpen(false); 
     };
 
-    // ⭐️ 로딩 및 에러 처리 조건부 렌더링 ⭐️
     if (isLoading) return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
     if (!detailData || detailData.days.length === 0) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다.</div>;
     if (currentDayIndex === -1 || !detailData.days[currentDayIndex]) return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
@@ -330,6 +328,7 @@ export default function TimetableDetailPage() {
     return (
         <div className={timetableStyles.pageContainer}>
             <header className={timetableStyles.header}>
+                {/* ⭐️ (연결) ⭐️ 뒤로 가기 버튼에 저장 로직이 포함된 handleGoBack 연결 */}
                 <button className={timetableStyles.backButton} onClick={handleGoBack}>
                     <img src={leftarrow} alt="뒤로 가기" />
                 </button>
@@ -358,9 +357,9 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            {/* 다운로드 버튼을 저장 버튼으로 재사용 */}
-                            <button className={timetableStyles.actionButton} onClick={handleSaveTimetable}>
-                                <img src={download} alt="저장"/>
+                            {/* ⭐️ (수정) ⭐️ 다운로드 버튼에서 저장 로직 제거 */}
+                            <button className={timetableStyles.actionButton} onClick={() => console.log("저장 기능이 뒤로 가기 버튼으로 이동했습니다.")}>
+                                <img src={download} alt="저장 기능 제거됨"/>
                             </button>
                             <button className={timetableStyles.actionButton} onClick={handleRefresh}>
                                 <img src={refresh} alt="되돌리기"/>
@@ -375,7 +374,6 @@ export default function TimetableDetailPage() {
                             stageMap={schedulesByStage.stageMap} 
                             allSchedules={allSchedules} 
                             mode={currentMode} 
-                            // ⭐️ (추가) ⭐️ 활성화 상태 관리 props 전달
                             onScheduleToggle={handleScheduleToggle}
                             activeScheduleKeys={activeScheduleKeys}
                         />

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import leftarrow from "../../assets/timetable/arrow-left.svg"
 
-// ⭐️ CSS 모듈명 변경: detailStyles -> timetableStyles ⭐️
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
 
 
@@ -12,41 +11,63 @@ import timetableStyles from "../../css/pages/timetable/timetabledetail.module.cs
 interface FestivalDetailData {
   festivalId: number;
   festivalTitle: string;
-  days: { date: string; stages: { stageName: string; }[] }[];
+  // date 속성은 'YYYY-MM-DD' 형식의 문자열로 가정합니다.
+  days: { date: string; stages: { stageName: string; }[] }[]; 
 }
 
-// 2. 임시 Mock 데이터를 Map 형태로 확장합니다. 
+// ⭐️ 날짜 형식 변환 유틸리티 함수 추가 ⭐️
+const formatDayAndDayOfWeek = (dateString: string): string => {
+    // 요일 배열 (한국어)
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+
+    const date = new Date(dateString);
+
+    // Date 객체 생성 시 유효하지 않은 날짜 포맷일 수 있으므로 유효성 검사 추가
+    if (isNaN(date.getTime())) {
+        console.error("Invalid date format:", dateString);
+        return dateString; 
+    }
+
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const dayOfWeek = weekdays[date.getDay()];
+
+    return `${month}.${day}(${dayOfWeek})`;
+};
+
+// ⭐️ 2. 임시 Mock 데이터를 YYYY-MM-DD 형식으로 수정 (함수 적용을 위해) ⭐️
 const MockFestivalDetails: Record<number, FestivalDetailData> = {
     1: {
         festivalId: 1, 
         festivalTitle: "그랜드 민트 페스티벌 2025",
         days: [
-            { date: "2025.12.20", stages: [{ stageName: "Mint Breeze Stage" }] }, 
-            { date: "2025.12.21", stages: [{ stageName: "Loving Forest Garden" }] }
+            // 형식 수정: YYYY-MM-DD
+            { date: "2025-12-20", stages: [{ stageName: "Mint Breeze Stage" }] }, 
+            { date: "2025-12-21", stages: [{ stageName: "Loving Forest Garden" }] }
         ],
     },
     2: {
         festivalId: 2,
         festivalTitle: "COUNTDOWN FANTASY 2025-2026",
         days: [
-            { date: "2025.12.30", stages: [{ stageName: "Fantasy Stage" }] }, 
-            { date: "2025.12.31", stages: [{ stageName: "New Year Stage" }] }
+            { date: "2025-12-30", stages: [{ stageName: "Fantasy Stage" }] }, 
+            { date: "2025-12-31", stages: [{ stageName: "New Year Stage" }] }
         ],
     },
     3: { 
         festivalId: 3, 
         festivalTitle: "COUNTDOWN FANTASY 2025-2026 (추천)", 
-        days: [{ date: "2025.12.20", stages: [{ stageName: "Stage A" }] }] 
+        days: [{ date: "2025-12-20", stages: [{ stageName: "Stage A" }] }] 
     },
     4: { 
         festivalId: 4, 
         festivalTitle: "DMZ 피스트레인 (추천)", 
-        days: [{ date: "2025.10.18", stages: [{ stageName: "Stage B" }] }] 
+        days: [{ date: "2025-10-18", stages: [{ stageName: "Stage B" }] }] 
     },
     7: { 
         festivalId: 7, 
         festivalTitle: "더 많은 페스티벌 1", 
-        days: [{ date: "2025.12.20", stages: [{ stageName: "Main Stage" }] }] 
+        days: [{ date: "2025-12-20", stages: [{ stageName: "Main Stage" }] }] 
     },
 };
 
@@ -64,7 +85,6 @@ export default function TimetableDetailPage() {
     
     const [currentDayIndex, setCurrentDayIndex] = useState(0);
 
-    // 4. 현재 모드 계산 (URL 분석)
     const currentMode: TimetableMode = useMemo(() => {
         if (location.pathname.includes('/my/')) return 'my';
         if (location.pathname.includes('/customize/')) return 'customize';
@@ -75,7 +95,6 @@ export default function TimetableDetailPage() {
         navigate(-1); 
     };
 
-    // 데이터 로딩 (API 호출 시뮬레이션)
     useEffect(() => {
         if (!festivalId) { 
             setIsLoading(false);
@@ -119,12 +138,10 @@ export default function TimetableDetailPage() {
     
     // --- 로딩/에러 처리 UI ---
     if (isLoading) {
-        // ⭐️ 클래스명 변경 적용 ⭐️
         return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;
     }
 
     if (!detailData) {
-        // ⭐️ 클래스명 변경 적용 ⭐️
         return <div className={timetableStyles.pageContainer}>요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
     }
 
@@ -133,12 +150,10 @@ export default function TimetableDetailPage() {
 
     // --- 메인 UI 렌더링 ---
     return (
-        // ⭐️ 클래스명 변경 적용 ⭐️
         <div className={timetableStyles.pageContainer}>
             
             <header className={timetableStyles.header}>
                 <button 
-                    // ⭐️ 클래스명 변경 적용 ⭐️
                     className={timetableStyles.backButton}
                     onClick={handleGoBack}
                 >
@@ -149,33 +164,42 @@ export default function TimetableDetailPage() {
                     {detailData.festivalTitle} 
                 </h1>
                 <div className={timetableStyles.emptyBox}></div>
-            
             </header>
 
             <main className={timetableStyles.mainContent}>
                 
-                {/* ⭐️ 1. 날짜 탭 UI ⭐️ */}
+               {/* ⭐️ 1. 날짜 드롭다운 UI ⭐️ */}
                 {detailData.days.length > 0 && (
-                    <div className={timetableStyles.dayTabs}>
-                        {detailData.days.map((day, index) => (
-                            <button
-                                key={index}
-                                // ⭐️ 클래스명 변경 적용 ⭐️
-                                className={`${timetableStyles.dayTab} ${
-                                    index === currentDayIndex ? timetableStyles.active : ''
-                                }`}
-                                onClick={() => setCurrentDayIndex(index)}
-                            >
-                                {day.date}
-                            </button>
-                        ))}
+                    <div className={timetableStyles.dayDropdownContainer}>
+                        
+                        {/* ⚠️ 레이블(label)은 접근성을 위해 유지하는 것을 권장합니다. */}
+                        {/* <label htmlFor="day-selector" className={timetableStyles.dayDropdownLabel}>날짜 선택</label> */}
+
+                        <select
+                            id="day-selector"
+                            className={timetableStyles.dayDropdown}
+                            value={currentDayIndex}
+                            onChange={(e) => setCurrentDayIndex(parseInt(e.target.value))}
+                        >
+                            {detailData.days.map((day, index) => (
+                                <option
+                                    key={index}
+                                    value={index} 
+                                >
+                                    {/* ⭐️ 날짜 형식 변환 함수 적용 ⭐️ */}
+                                    {formatDayAndDayOfWeek(day.date)}
+                                </option>
+                            ))}
+                        </select>
+
                     </div>
                 )}
                 
                 {/* ⭐️ 2. 선택된 날짜의 스테이지/일정 영역 ⭐️ */}
                 <div className={timetableStyles.scheduleArea}>
                     
-                    <h3>{selectedDayData.date} 일정</h3>
+                    {/* ⭐️ 제목에도 변환된 날짜 적용 ⭐️ */}
+                    <h3>{formatDayAndDayOfWeek(selectedDayData.date)} 일정</h3>
                     
                     {/* TODO: 여기에 스테이지 필터와 실제 타임테이블 목록이 들어갑니다. */}
                     <div style={{ marginTop: '10px', padding: '10px', border: '1px solid #ccc' }}>

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 완료 버전)
+// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 완료 버전 - my-detail 적용)
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -11,7 +11,16 @@ import timetableStyles from "../../css/pages/timetable/timetabledetail.module.cs
 import TimetableGrid from "../../components/timetable/TimetableGrid"; 
 import api from "../../api/api"; // Axios 인스턴스
 
-// ⭐️ Kopis API 응답 타입 ⭐️
+// ⭐️ 시간 객체 타입 (공통 사용) ⭐️
+interface TimeObject {
+    hour: number;
+    minute: number;
+    second: number;
+    nano: number;
+}
+
+
+// ⭐️ Kopis API 응답 타입 (기본 공연 정보) ⭐️
 export interface KopisFestivalItem {
    id: number; 
   mt20id: string; 
@@ -26,36 +35,43 @@ export interface KopisFestivalItem {
   prfstate: string; 
   dtguidance: string; 
   tkstdate: string; 
-  tksttime: { hour: number; minute: number; second: number; nano: number; };
+  tksttime: TimeObject;
   typeofcon: number;
   newstate: boolean;
   locationUrl: string;
   styurls: { relatenm: string; relateurl: string; }[];
   relates: { relatenm: string; relateurl: string; }[];
-  days: { date: string; open: { hour: number; minute: number; second: number; nano: number; }; close: { hour: number; minute: number; second: number; nano: number; }; }[];
-  slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: { hour: number; minute: number; second: number; nano: number; }; end: { hour: number; minute: number; second: number; nano: number; }; minutes: number; img: string; note: string; }[];
+  days: { date: string; open: TimeObject; close: TimeObject; }[]; // Kopis days 타입
+  slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: TimeObject; end: TimeObject; minutes: number; img: string; note: string; }[]; // Kopis slots 타입
   fesLinks: { relatenm: string; relateurl: string; }[];
   artistPics: { date: string; relatenm: string; url: string; }[];
 }
 
-// ⭐️ 서버의 /festivals/{mt20id}/detail 응답 타입 정의 ⭐️
+// ⭐️ 서버의 /festivals/{mt20id}/my-detail 응답 타입 정의 ⭐️
+// (사용자님이 제공해주신 응답 스키마와 일치하도록 반영)
 export interface CustomDetailAPIItem {
     mt20id: string; 
     prfnm: string; 
-    hasCustom: boolean;
+    prfpdfrom: string; 
+    prfpdto: string; 
+    fcltynm: string; 
+    locationUrl: string;
+    hasCustom: boolean; // 커스텀 내역 존재 여부
+    days: { date: string; open: TimeObject; close: TimeObject; }[]; // my-detail days 타입
     slots: { 
         date: string; 
         stageId: string; 
         stageName: string; 
         stageOrder: number; 
         artist: string; 
-        start: { hour: number; minute: number; second: number; nano: number; } | string; 
-        end: { hour: number; minute: number; second: number; nano: number; } | string; 
+        start: TimeObject | string; // TimeObject 또는 string 처리
+        end: TimeObject | string; 
         minutes: number; 
         img: string | null; 
         note: string | null; 
         inverted?: boolean; // 사용자가 선택했는지 여부
     }[];
+    artistPics: { date: string; relatenm: string; url: string; }[];
 }
 
 export interface ScheduleItem { 
@@ -85,6 +101,15 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
 
 type TimetableMode = 'customize' | 'my' | 'view'; 
 
+// ⭐️ TimeObject 또는 string을 "HH:MM:SS" 문자열로 변환하는 헬퍼 함수 ⭐️
+const timeToTimeString = (time: any): string => {
+    if (typeof time === 'string') return time;
+    const hour = time?.hour ?? 0;
+    const minute = time?.minute ?? 0;
+    return `${hour.toString().padStart(2,'0')}:${minute.toString().padStart(2,'0')}:00`;
+};
+
+
 // ⭐️ 1. Kopis API 호출 및 데이터 변환 함수 (기본 데이터 로드) ⭐️
 async function fetchAndProcessTimetableDetail(
     festivalId: string | undefined, 
@@ -103,7 +128,7 @@ async function fetchAndProcessTimetableDetail(
     let processedData: FestivalDetailData | null = null;
     
     try {
-        // Kopis API 엔드포인트 사용
+        // Kopis API 엔드포인트 사용 (기본 데이터 구조 로드)
         const response = await api.get(`/kopis/performances/festivals?festivalId=${idNum}`); 
         
         const rawData = response.data.data || response.data;
@@ -124,15 +149,6 @@ async function fetchAndProcessTimetableDetail(
 
         apiData.slots.forEach(slot => {
             const dateString = slot.date;
-            
-            const timeObjToString = (time: any) => {
-                const hour = time.hour ?? 0;
-                const minute = time.minute ?? 0;
-                return `${hour.toString().padStart(2,'0')}:${minute.toString().padStart(2,'0')}:00`;
-            };
-
-            const startString = typeof slot.start === 'string' ? slot.start : timeObjToString(slot.start);
-            const endString = typeof slot.end === 'string' ? slot.end : timeObjToString(slot.end);
 
             const scheduleItem: ScheduleItem = {
                 date: slot.date,
@@ -140,8 +156,8 @@ async function fetchAndProcessTimetableDetail(
                 stageName: slot.stageName,
                 stageOrder: slot.stageOrder, 
                 artist: slot.artist,
-                start: startString, 
-                end: endString,     
+                start: timeToTimeString(slot.start), // 헬퍼 함수 사용
+                end: timeToTimeString(slot.end),     // 헬퍼 함수 사용
                 minutes: slot.minutes,
                 img: slot.img || null,
                 note: slot.note || null,
@@ -175,33 +191,33 @@ async function fetchAndProcessTimetableDetail(
     return processedData;
 }
 
-// ⭐️ 2. 사용자 커스텀 슬롯만 가져오는 함수 ⭐️
+// ⭐️ 2. 사용자 커스텀 슬롯만 가져오는 함수 (my-detail API 사용) ⭐️
 async function fetchCustomSlots(
     mt20id: string,
     setActiveScheduleKeys: (keys: Set<string>) => void
 ): Promise<void> {
-    const API_URL = `/festivals/${mt20id}/detail`;
+    // ⭐️ API URL 변경 적용: detail -> my-detail (요청하신 대로) ⭐️
+    const API_URL = `/festivals/${mt20id}/my-detail`; 
     
     try {
         const response = await api.get(API_URL);
-        const apiData: CustomDetailAPIItem = response.data.data || response.data;
+        // 응답 데이터가 배열이 아닌 CustomDetailAPIItem 형식이라고 가정합니다.
+        const apiData: CustomDetailAPIItem = response.data.data || response.data; 
         
         const initialActiveKeys = new Set<string>();
 
-        if (apiData.hasCustom && apiData.slots) {
+        // hasCustom이 true이고 slots가 존재하며, slots가 배열인지 확인
+        if (apiData.hasCustom && Array.isArray(apiData.slots)) {
             apiData.slots.forEach(slot => {
-                 const timeObjToString = (time: any) => {
-                    const hour = time.hour ?? 0;
-                    const minute = time.minute ?? 0;
-                    return `${hour.toString().padStart(2,'0')}:${minute.toString().padStart(2,'0')}:00`;
-                };
-
-                const startString = typeof slot.start === 'string' ? slot.start : timeObjToString(slot.start);
-
+                const startString = timeToTimeString(slot.start); // 헬퍼 함수 사용
+                
                 if (slot.inverted === true) {
                      // ScheduleItem의 키 생성 방식과 동일하게 구성
-                     const scheduleKey = `${slot.date}-${slot.stageId}-${slot.artist}-${startString}`;
-                     initialActiveKeys.add(scheduleKey);
+                     // slot.artist가 없을 경우를 대비해 artist 필드가 있음을 확인
+                     if (slot.artist) {
+                         const scheduleKey = `${slot.date}-${slot.stageId}-${slot.artist}-${startString}`;
+                         initialActiveKeys.add(scheduleKey);
+                     }
                 }
             });
         }
@@ -251,16 +267,22 @@ export default function TimetableDetailPage() {
 
 
     const currentMode: TimetableMode = useMemo(() => {
+        // 커스텀 내역은 'my' 모드와 'customize' 모드에서 모두 필요하지만,
+        // 사용자 데이터를 가져오는 것은 'my'와 'customize' 모드가 구분되지 않는 경우가 많습니다.
+        // 현재 로직은 'my' 모드에서만 fetchCustomSlots을 호출하지만,
+        // 요청의 의도("나의 타임테이블 뿐 아니라 더많은 타임테이블에서도 보고싶어서")에 따라
+        // API 호출은 모든 커스텀 가능한 페이지에서 필요할 수 있습니다.
+        // 일단 기존 로직대로 'my'/'customize'를 구분하되, fetchCustomSlots을 호출하도록 유지합니다.
+        
         if (location.pathname.includes('/my/')) return 'my';
         if (location.pathname.includes('/customize/')) return 'customize';
         return 'view'; 
     }, [location.pathname]);
     
-    // ⭐️ [수정] getPayloadAndCheckSelection 함수: 현재 날짜가 아닌 페스티벌 전체 스케줄을 포함하도록 수정 ⭐️
+    // getPayloadAndCheckSelection 함수는 이전과 동일
     const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
         if (!detailData || !detailData.mt20id) return { payload: null, hasSelections: false };
         
-        // ⭐️ [수정] currentDayIndex 대신, detailData.days 전체를 순회하여 모든 스케줄을 모읍니다. ⭐️
         let allFestivalSchedules: ScheduleItem[] = [];
         detailData.days.forEach(day => {
             allFestivalSchedules = allFestivalSchedules.concat(day.schedules);
@@ -269,7 +291,6 @@ export default function TimetableDetailPage() {
         const invertedSlots: any[] = [];
         let finalHasSelections = false;
 
-        // ⭐️ [수정] 페스티벌 전체 스케줄(allFestivalSchedules)을 순회합니다. ⭐️
         allFestivalSchedules.forEach(schedule => {
             const key = createScheduleKey(schedule);
             const isInverted = activeScheduleKeys.has(key); 
@@ -277,7 +298,6 @@ export default function TimetableDetailPage() {
             if (isInverted) {
                 finalHasSelections = true; // 하나라도 선택되면 true
                 
-                // 선택된 슬롯만 페이로드에 포함합니다.
                 invertedSlots.push({
                     date: schedule.date,
                     stageOrder: Number(schedule.stageOrder), 
@@ -289,7 +309,7 @@ export default function TimetableDetailPage() {
         
         const payload: { mt20id: string; invertedSlots: any[] } = {
             mt20id: detailData.mt20id, 
-            invertedSlots: invertedSlots // 이제 이 배열은 모든 날짜의 선택된 슬롯을 포함합니다.
+            invertedSlots: invertedSlots 
         };
         
         return { payload, hasSelections: finalHasSelections };
@@ -326,26 +346,29 @@ export default function TimetableDetailPage() {
         }
     }, [festivalId]);
     
-    // ⭐️ 2. detailData 로드 후, 'my' 모드일 때만 커스텀 슬롯 API 호출 ⭐️
+    // ⭐️ 2. detailData 로드 후, 커스텀 슬롯 API 호출 (my-detail API는 인증된 사용자의 데이터만 가져옴) ⭐️
     useEffect(() => {
-        if (detailData && detailData.mt20id && currentMode === 'my') {
+        // 'my' 모드뿐 아니라 'customize' 모드에서도 커스텀 내역을 가져와야
+        // 사용자가 이전에 선택한 것을 기반으로 수정을 시작할 수 있습니다.
+        if (detailData && detailData.mt20id && (currentMode === 'my' || currentMode === 'customize')) { 
+            // 커스텀 내역을 불러와 activeScheduleKeys에 설정합니다.
             fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
-        } 
+        } else if (currentMode === 'view') {
+            // view 모드에서는 커스텀 내역이 필요 없으므로 초기화
+            setActiveScheduleKeys(new Set());
+        }
     }, [detailData, currentMode]); 
 
-    // ⭐️ [수정] saveTimetableData 함수: 선택 여부와 관계없이 POST 요청을 보내도록 수정 ⭐️
+    // saveTimetableData 함수는 이전과 동일 (선택 상태가 없어도 POST 요청을 보내어 삭제 명령을 서버에 전달)
     const saveTimetableData = async (): Promise<boolean> => { 
         
-        const { payload, hasSelections } = getPayloadAndCheckSelection(); // 이제 페스티벌 전체의 선택 상태를 가져옴
+        const { payload, hasSelections } = getPayloadAndCheckSelection(); 
 
         if (!payload || !payload.mt20id) {
             console.error("⚠️ 저장할 데이터가 준비되지 않았습니다. (mt20id 누락)");
             return false;
         }
         
-        // ⭐️ [수정] 선택된 슬롯이 0개일 때도 POST 요청을 보내어 삭제 명령을 서버에 전달합니다. ⭐️
-        // (이전 코드에서는 hasSelections가 false일 때 return true로 빠져나갔음)
-
         const mt20id = payload.mt20id;
         const API_ENDPOINT = `/festivals/${mt20id}/custom-slots`; 
         const HTTP_METHOD = 'POST'; 
@@ -394,7 +417,6 @@ export default function TimetableDetailPage() {
         else { setDetailData(null); setIsLoading(false); }
     };
     
-    // ⭐️ ⭐️ [오류 수정] handleDaySelect 함수를 컴포넌트 내부로 이동 ⭐️ ⭐️
     const handleDaySelect = (index: number) => { 
         setCurrentDayIndex(index); 
         setIsDropdownOpen(false); 

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -13,19 +13,29 @@ import api from "../../api/api"; // Axios 인스턴스
 
 // ⭐️ Kopis API 응답 타입 ⭐️
 export interface KopisFestivalItem {
-  id: number; 
+   id: number; 
+  mt20id: string; // <-- 이 값을 사용합니다.
   prfnm: string; 
   prfpdfrom: string; 
   prfpdto: string; 
   fcltynm: string; 
-  days: { date: string; open: any; close: any; }[]; 
-  slots: { 
-    date: string; stageId: string; stageName: string; stageOrder: number; 
-    artist: string; 
-    start: string | { hour: number; minute: number; second: number; nano: number; }; 
-    end: string | { hour: number; minute: number; second: number; nano: number; }; 
-    minutes: number; img: string | null; note: string | null; 
-  }[];
+  prfruntime: string; 
+  prfage: string; 
+  pcseguidance: string; 
+  poster: string; 
+  prfstate: string; 
+  dtguidance: string; 
+  tkstdate: string; 
+  tksttime: { hour: number; minute: number; second: number; nano: number; };
+  typeofcon: number;
+  newstate: boolean;
+  locationUrl: string;
+  styurls: { relatenm: string; relateurl: string; }[];
+  relates: { relatenm: string; relateurl: string; }[];
+  days: { date: string; open: { hour: number; minute: number; second: number; nano: number; }; close: { hour: number; minute: number; second: number; nano: number; }; }[];
+  slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: { hour: number; minute: number; second: number; nano: number; }; end: { hour: number; minute: number; second: number; nano: number; }; minutes: number; img: string; note: string; }[];
+  fesLinks: { relatenm: string; relateurl: string; }[];
+  artistPics: { date: string; relatenm: string; url: string; }[];
 }
 export interface ScheduleItem { 
   date: string; stageId: string; stageName: string; stageOrder: number; 
@@ -33,8 +43,10 @@ export interface ScheduleItem {
   img: string | null; note: string | null; isCustomized?: boolean; 
 }
 interface DayScheduleData { date: string; schedules: ScheduleItem[]; }
+// ⭐️ mt20id 필드 추가
 interface FestivalDetailData { 
     festivalId: number; 
+    mt20id: string; // API 응답에서 받은 고유 ID
     festivalTitle: string; 
     days: DayScheduleData[]; 
 }
@@ -84,6 +96,9 @@ async function fetchAndProcessTimetableDetail(
             setIsLoading(false);
             return null;
         }
+        
+        // ⭐️ (추가) ⭐️ mt20id가 누락되었을 경우를 대비해 festivalId를 폴백으로 사용
+        const mt20idValue = apiData.mt20id || festivalId;
 
         const schedulesByDateMap: Record<string, ScheduleItem[]> = {};
 
@@ -113,7 +128,8 @@ async function fetchAndProcessTimetableDetail(
                 date: slot.date,
                 stageId: slot.stageId,
                 stageName: slot.stageName,
-                stageOrder: slot.stageOrder,
+                // 주의: slot.stageOrder는 이미 Number 타입으로 가정되지만, 아래에서 Number()로 한번 더 변환하여 안전성 확보
+                stageOrder: slot.stageOrder, 
                 artist: slot.artist,
                 start: startString, 
                 end: endString,     
@@ -133,6 +149,7 @@ async function fetchAndProcessTimetableDetail(
 
         processedData = {
             festivalId: idNum,
+            mt20id: mt20idValue, // ⭐️ API에서 가져온 mt20id 저장
             festivalTitle: apiData.prfnm,
             days: processedDays
         };
@@ -191,14 +208,16 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
     
-    // ⭐️ (수정) ⭐️ 페이로드 생성 시 선택 여부(hasSelections)도 함께 반환하도록 수정
+    // ⭐️ (수정된 함수) ⭐️ 페이로드 생성 시 detailData.mt20id 사용, 타입 캐스팅 및 필터링 적용
     const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
-        if (!detailData || currentDayIndex === -1) return { payload: null, hasSelections: false };
+        // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청을 할 수 없음
+        if (!detailData || currentDayIndex === -1 || !detailData.mt20id) return { payload: null, hasSelections: false };
         
         const currentDaySchedules = detailData.days[currentDayIndex]?.schedules || [];
         let hasSelections = false;
 
-        const invertedSlots = currentDaySchedules.map(schedule => {
+        // 1. 모든 스케줄을 매핑하여 inverted 상태를 포함한 슬롯 객체 생성
+        const allSlots = currentDaySchedules.map(schedule => {
             const key = createScheduleKey(schedule);
             const isInverted = activeScheduleKeys.has(key); 
             
@@ -208,21 +227,26 @@ export default function TimetableDetailPage() {
             
             return {
                 date: schedule.date,
-                stageOrder: schedule.stageOrder,
+                // ⭐️⭐️ 수정 1: stageOrder를 Number() 함수로 감싸서 확실히 숫자 타입으로 전송 (백엔드 타입 오류 방지) ⭐️⭐️
+                stageOrder: Number(schedule.stageOrder), 
                 artist: schedule.artist,
                 inverted: isInverted 
             };
         });
 
-        // ⚠️ 이 mt20id는 실제 사용자 ID 또는 타임테이블 고유 ID로 대체되어야 합니다.
-        const TEMP_MT20ID = "TEMP_USER_OR_TABLE_ID"; 
-
+        // 2. ⭐️⭐️ 수정 2: inverted: true 인 항목만 필터링하여 전송 (서버가 수정 대상만 받기를 기대할 경우 오류 방지) ⭐️⭐️
+        const invertedSlots = allSlots.filter(slot => slot.inverted === true);
+        
+        // 필터링 후에도 선택된 항목이 있는지 다시 확인
+        const finalHasSelections = invertedSlots.length > 0;
+        
         const payload = {
-            mt20id: TEMP_MT20ID, 
+            mt20id: detailData.mt20id, 
             invertedSlots: invertedSlots
         };
         
-        return { payload, hasSelections };
+        // 선택된 항목이 없으면 payload가 null은 아니지만, hasSelections가 false임을 반환
+        return { payload, hasSelections: finalHasSelections };
     };
 
 
@@ -255,13 +279,16 @@ export default function TimetableDetailPage() {
         }
     }, [festivalId]);
     
-    // ⭐️ (추가) ⭐️ 핵심 저장 로직. 성공/건너뛰면 true, 실패하면 false 반환
+    // ⭐️ 핵심 저장 로직. 성공/건너뛰면 true, 실패하면 false 반환
     const saveTimetableData = async (): Promise<boolean> => { 
         const { payload, hasSelections } = getPayloadAndCheckSelection();
 
-        if (!payload) return true;
+        // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청 건너뛰기
+        if (!payload) {
+            console.log("⚠️ 저장할 데이터가 준비되지 않았습니다. (mt20id 누락 또는 데이터 로딩 문제)");
+            return true;
+        }
         
-        // ⭐️ 조건: 선택된 스케줄이 없으면 서버에 저장 요청을 건너뜁니다. ⭐️
         if (!hasSelections) {
             console.log("ℹ️ 선택된 스케줄이 없어 서버에 저장 요청을 건너뜁니다.");
             return true; 
@@ -282,21 +309,20 @@ export default function TimetableDetailPage() {
 
         } catch (error) {
             const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
-            console.error(`❌ 타임테이블 저장 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error);
+            // ⭐️ 500 에러 메시지 콘솔 출력 ⭐️
+            console.error(`❌ 타임테이블 저장 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error); 
             alert(`타임테이블 저장 중 오류가 발생했습니다: ${errorMessage}`);
             return false;
         }
     };
     
-    // ⭐️ (수정) ⭐️ 뒤로 가기 버튼 클릭 시 저장 로직 실행 후 이동
+    // ⭐️ 뒤로 가기 버튼 클릭 시 저장 로직 실행 후 이동
     const handleGoBack = async () => {
         const saveSuccessful = await saveTimetableData();
 
-        // 저장에 성공했거나 (true), 데이터가 없어 건너뛰었을 경우 (true), 뒤로 이동
         if (saveSuccessful) {
             navigate(-1);
         } else {
-            // 저장 실패 시 (false) 경고창을 띄우고 페이지에 머무름
             console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
         }
     };
@@ -316,7 +342,8 @@ export default function TimetableDetailPage() {
     };
 
     if (isLoading) return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
-    if (!detailData || detailData.days.length === 0) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다.</div>;
+    // detailData.mt20id도 확인
+    if (!detailData || detailData.days.length === 0 || !detailData.mt20id) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다. (ID 누락 확인)</div>;
     if (currentDayIndex === -1 || !detailData.days[currentDayIndex]) return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
 
     const selectedDayData = detailData.days[currentDayIndex];
@@ -328,7 +355,7 @@ export default function TimetableDetailPage() {
     return (
         <div className={timetableStyles.pageContainer}>
             <header className={timetableStyles.header}>
-                {/* ⭐️ (연결) ⭐️ 뒤로 가기 버튼에 저장 로직이 포함된 handleGoBack 연결 */}
+                {/* ⭐️ 뒤로 가기 버튼에 저장 로직이 포함된 handleGoBack 연결 */}
                 <button className={timetableStyles.backButton} onClick={handleGoBack}>
                     <img src={leftarrow} alt="뒤로 가기" />
                 </button>
@@ -357,7 +384,7 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            {/* ⭐️ (수정) ⭐️ 다운로드 버튼에서 저장 로직 제거 */}
+                            {/* 다운로드 버튼은 기능이 제거됨 */}
                             <button className={timetableStyles.actionButton} onClick={() => console.log("저장 기능이 뒤로 가기 버튼으로 이동했습니다.")}>
                                 <img src={download} alt="저장 기능 제거됨"/>
                             </button>

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 버전: 시간 타입 유연성 확보)
+// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 버전: 시간 타입 유연성 확보 및 상태 관리)
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -7,7 +7,6 @@ import leftarrow from "../../assets/timetable/arrow-left.svg";
 import downarrow from "../../assets/timetable/arrow-down.svg";
 import download from "../../assets/timetable/download.svg";
 import refresh from "../../assets/timetable/refresh.svg";
-
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; // 경로 확인 필요
 import TimetableGrid from "../../components/timetable/TimetableGrid"; 
 import api from "../../api/api"; 
@@ -40,6 +39,10 @@ interface FestivalDetailData {
     festivalTitle: string; 
     days: DayScheduleData[]; 
 }
+
+// ⭐️ (추가) ⭐️ 스케줄 아이템의 고유 키를 생성하는 헬퍼 함수
+// date, stageId, artist, start 시간을 조합하여 고유한 문자열을 만듭니다.
+const createScheduleKey = (s: ScheduleItem) => `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
 
 const formatDayAndDayOfWeek = (dateString: string): string => {
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
@@ -185,11 +188,75 @@ export default function TimetableDetailPage() {
     const [currentDayIndex, setCurrentDayIndex] = useState(-1);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+    // ⭐️ (추가) ⭐️ 선택된 스케줄을 추적하는 상태 (Set 사용)
+    const [activeScheduleKeys, setActiveScheduleKeys] = useState<Set<string>>(new Set());
+    
+    // ⭐️ (수정/추가) ⭐️ 스케줄을 클릭했을 때 상태를 토글하는 함수
+    const handleScheduleToggle = (schedule: ScheduleItem) => {
+        const key = createScheduleKey(schedule);
+        
+        // ⭐️ (수정) ⭐️ const로 명확하게 선언하여 스코프 오류를 해결합니다.
+        // 현재 상태를 기준으로 클릭 후의 예상 상태를 미리 계산합니다.
+        const newStateIsActive = !activeScheduleKeys.has(key); 
+
+        setActiveScheduleKeys(prev => {
+            const newSet = new Set(prev);
+            if (newSet.has(key)) {
+                newSet.delete(key); // 이미 선택되었으면 제거 (inverted: false)
+            } else {
+                newSet.add(key); // 선택되지 않았으면 추가 (inverted: true)
+            }
+            return newSet;
+        });
+        
+        // ⭐️ (수정) 콘솔 로깅으로 inverted 여부 확인 ⭐️
+        console.log("--- Schedule Toggled ---");
+        console.log("Date:", schedule.date);
+        console.log("Artist:", schedule.artist);
+        console.log("Stage Order:", schedule.stageOrder);
+        // 계산된 로컬 변수 newStateIsActive를 사용합니다.
+        console.log("Inverted/Selected (New State):", newStateIsActive);
+        console.log("------------------------");
+        
+        // ⭐️ (추가) ⭐️ 상태 변경 후 페이로드 생성 함수를 호출할 수 있습니다.
+        // 예를 들어: createAndSendInvertedSlotsPayload();
+    };
+
     const currentMode: TimetableMode = useMemo(() => {
         if (location.pathname.includes('/my/')) return 'my';
         if (location.pathname.includes('/customize/')) return 'customize';
         return 'view'; 
     }, [location.pathname]);
+    
+    // ⭐️ (추가) ⭐️ 서버 전송 페이로드를 생성하는 함수 (나중에 버튼에 연결)
+    const createInvertedSlotsPayload = (): { mt20id: string; invertedSlots: any[] } | null => {
+        if (!detailData || currentDayIndex === -1) return null;
+        
+        const currentDaySchedules = detailData.days[currentDayIndex]?.schedules || [];
+
+        // 현재 날짜의 모든 스케줄을 순회하며 inverted 여부를 결정합니다.
+        const invertedSlots = currentDaySchedules.map(schedule => {
+            const key = createScheduleKey(schedule);
+            const isInverted = activeScheduleKeys.has(key); // Set에 있으면 true (선택됨)
+            
+            return {
+                date: schedule.date,
+                stageOrder: schedule.stageOrder,
+                artist: schedule.artist,
+                // ⭐️ 활성화 상태를 inverted 필드 값으로 사용 ⭐️
+                inverted: isInverted 
+            };
+        });
+
+        const payload = {
+            mt20id: "TEMP_USER_ID_OR_MT_ID", // 실제 사용자 ID나 테이블 ID로 대체
+            invertedSlots: invertedSlots
+        };
+        
+        console.log("🚀 서버 전송 페이로드 미리보기:", payload);
+        return payload;
+    };
+
 
     const allSchedules = useMemo(() => {
         if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
@@ -224,11 +291,22 @@ export default function TimetableDetailPage() {
 
 
     const handleGoBack = () => navigate(-1);
-    const handleDownload = () => console.log("Download clicked");
+    
+    // ⭐️ (수정) ⭐️ 다운로드 버튼을 서버 저장 버튼으로 가정하고 페이로드 생성 로직 연결
+    const handleSaveTimetable = () => {
+        const payload = createInvertedSlotsPayload();
+        if (payload) {
+            console.log("Saving timetable to server...", payload);
+            // 여기에 api.put('/mytimetable', payload) 같은 서버 저장 로직 추가
+        }
+    };
+    
     const handleRefresh = () => {
         console.log("🔄 Refreshing data from API.");
         setCurrentDayIndex(-1); 
         setIsDropdownOpen(false);
+        // ⭐️ (추가) ⭐️ 새로고침 시 선택 상태도 초기화
+        setActiveScheduleKeys(new Set()); 
         if (festivalId) fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
         else { setDetailData(null); setIsLoading(false); }
     };
@@ -280,8 +358,9 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            <button className={timetableStyles.actionButton} onClick={handleDownload}>
-                                <img src={download} alt="다운로드"/>
+                            {/* 다운로드 버튼을 저장 버튼으로 재사용 */}
+                            <button className={timetableStyles.actionButton} onClick={handleSaveTimetable}>
+                                <img src={download} alt="저장"/>
                             </button>
                             <button className={timetableStyles.actionButton} onClick={handleRefresh}>
                                 <img src={refresh} alt="되돌리기"/>
@@ -296,6 +375,9 @@ export default function TimetableDetailPage() {
                             stageMap={schedulesByStage.stageMap} 
                             allSchedules={allSchedules} 
                             mode={currentMode} 
+                            // ⭐️ (추가) ⭐️ 활성화 상태 관리 props 전달
+                            onScheduleToggle={handleScheduleToggle}
+                            activeScheduleKeys={activeScheduleKeys}
                         />
                     </div></div>
                     

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,9 +1,9 @@
-// src/pages/timetable/TimetableDetailPage.tsx (Refresh 로직 수정 및 캡처 기능 추가)
+// src/pages/timetable/TimetableDetailPage.tsx (순수 타임테이블 영역 캡처 최종 버전)
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import type { Location } from "react-router-dom"; 
-// ⭐️ [추가] html2canvas 임포트
+// ⭐️ [필수] html2canvas 임포트 (설치가 필요합니다: npm install html2canvas)
 import html2canvas from 'html2canvas';
 
 import leftarrow from "../../assets/timetable/arrow-left.svg";
@@ -270,7 +270,7 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
     
-    const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
+    const getPayloadAndCheckSelection = useCallback((): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
         if (!detailData || !detailData.mt20id) return { payload: null, hasSelections: false };
         
         let allFestivalSchedules: ScheduleItem[] = [];
@@ -303,7 +303,7 @@ export default function TimetableDetailPage() {
         };
         
         return { payload, hasSelections: finalHasSelections };
-    };
+    }, [detailData, activeScheduleKeys]);
 
     const allSchedules = useMemo(() => {
         if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
@@ -338,8 +338,6 @@ export default function TimetableDetailPage() {
     
     // ⭐️ 2. detailData 로드 후, 커스텀 슬롯 API 호출 ⭐️
     useEffect(() => {
-        // detailData 로드 후, 'my' 또는 'customize' 모드에서만 서버에 저장된 커스텀 슬롯을 불러옵니다.
-        // 이 로직 때문에, API 재호출을 포함한 기존 Refresh 함수는 로컬 초기화가 덮어씌워지는 문제가 있었습니다.
         if (detailData && detailData.mt20id && (currentMode === 'my' || currentMode === 'customize')) { 
             fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
         } else if (currentMode === 'view') {
@@ -347,8 +345,8 @@ export default function TimetableDetailPage() {
         }
     }, [detailData, currentMode]); 
 
-    // ⭐️⭐️ [Alert 제거] 저장/삭제 성공 메시지를 console.log로 대체 ⭐️⭐️
-    const saveTimetableData = async (): Promise<boolean> => { 
+    // ⭐️⭐️ 저장/삭제 로직 ⭐️⭐️
+    const saveTimetableData = useCallback(async (): Promise<boolean> => { 
         
         const { payload, hasSelections } = getPayloadAndCheckSelection(); 
 
@@ -370,7 +368,6 @@ export default function TimetableDetailPage() {
         try {
             const response = await api.post(API_ENDPOINT, payload); 
 
-            // ⚠️ 성공 메시지를 console.log로 대체
             const successMessage = hasSelections 
                 ? "나의 타임테이블이 성공적으로 서버에 저장되었습니다. 🥳" 
                 : "나의 타임테이블이 성공적으로 서버에서 삭제되었습니다. 🗑️";
@@ -381,11 +378,10 @@ export default function TimetableDetailPage() {
         } catch (error) {
             const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
             
-            // ⚠️ 실패 메시지를 console.error로 대체
             console.error(`❌ 타임테이블 저장/삭제 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, errorMessage, error); 
             return false;
         }
-    };
+    }, [getPayloadAndCheckSelection]);
     
     // 뒤로 가기 버튼 클릭 시 저장 로직이 포함된 handleGoBack 연결
     const handleGoBack = async () => {
@@ -395,7 +391,6 @@ export default function TimetableDetailPage() {
                 // 저장 성공 시에만 뒤로 이동
                 navigate(-1);
             } else {
-                // 저장 실패 시 사용자에게 알림 없이 콘솔에만 기록하고 이동 취소
                 console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
             }
         } else {
@@ -403,42 +398,60 @@ export default function TimetableDetailPage() {
         }
     };
     
-    // ⭐️⭐️ [FIX] handleRefresh 수정: 기본 데이터 재로드 로직 제거 ⭐️⭐️
+    // ⭐️⭐️ Refresh 로직: 현재 로컬 선택 상태 초기화 ⭐️⭐️
     const handleRefresh = () => {
-        // 변경: 현재 로컬에서 선택된 내용만 즉시 모두 해제(false)하도록 수정합니다.
         console.log("🔄 Refresh 버튼 클릭: 현재 로컬에서 선택된 모든 스케줄을 초기화합니다.");
         
         setActiveScheduleKeys(new Set()); // 모든 선택 상태를 빈 Set으로 초기화
         setIsDropdownOpen(false); // 드롭다운 닫기
     };
 
-    // ⭐️⭐️ [추가] 캡처 로직 (Download 버튼에 연결) ⭐️⭐️
+    // ⭐️⭐️ [FIX] 캡처 로직 (순수 타임테이블 영역만 캡처 최종) ⭐️⭐️
     const handleCaptureAndDownload = async () => {
-        console.log("📸 이미지 캡처 시작...");
+        console.log("📸 이미지 캡처 시작 (순수 타임테이블 영역)...");
         
-        // TimetableGrid를 감싸는 고유 ID를 가진 요소
         const inputElement = document.getElementById('timetable-capture-area');
 
         if (!inputElement) {
             console.error("⚠️ 캡처 대상 요소를 찾을 수 없습니다. (ID: timetable-capture-area)");
+            // 사용자에게 피드백 제공
+            alert("캡처 대상 요소를 찾을 수 없습니다. 개발자에게 문의하거나 페이지를 새로고침 해보세요.");
             return;
         }
         
-        // 캡처 실행 (긴 콘텐츠를 위해 scroll, scale 옵션 사용)
+        // 캡처 대상 요소의 정확한 스크롤 크기를 가져옴
+        const contentWidth = inputElement.scrollWidth;
+        const contentHeight = inputElement.scrollHeight;
+
         try {
             const canvas = await html2canvas(inputElement, {
-                useCORS: true, // 외부 이미지 (포스터 등) 로드를 위해 필수
-                scale: 2,       // 고해상도 출력을 위해 스케일 조정 (선택 사항)
-                // 긴 타임테이블이 컨테이너 내부에 스크롤되어도 전체를 캡처하도록 설정
-                windowWidth: inputElement.scrollWidth,
-                windowHeight: inputElement.scrollHeight,
+                useCORS: true, 
+                scale: 2,       
+                
+                // ⭐️ 캡처할 영역의 실제 콘텐츠 크기만 지정 (잘림 방지) ⭐️
+                width: contentWidth,
+                height: contentHeight,
+                
+                // 캡처 시작점을 요소의 왼쪽 상단(0, 0)으로 고정
+                scrollX: 0,
+                scrollY: 0,
+                
+                // ⭐️ 배경색을 흰색으로 명시하여 주변의 불필요한 투명 여백 방지 ⭐️
+                backgroundColor: '#ffffff', 
+                
+                // 캡처가 뷰포트 크기에 종속되지 않도록 콘텐츠 크기로 뷰포트 옵션을 대체
+                windowWidth: contentWidth, 
+                windowHeight: contentHeight, 
             });
 
             // 다운로드 링크 생성 및 클릭
             const image = canvas.toDataURL('image/png');
             const a = document.createElement('a');
             a.href = image;
-            a.download = `${detailData?.festivalTitle || 'Timetable'}_${formatDayAndDayOfWeek(selectedDayData.date).replace(/[\.()]/g, '')}.png`;
+            
+            const dateStr = selectedDayData ? formatDayAndDayOfWeek(selectedDayData.date).replace(/[\.()]/g, '_') : '';
+            a.download = `${detailData?.festivalTitle || 'Timetable'}_${dateStr}.png`;
+            
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);
@@ -447,6 +460,7 @@ export default function TimetableDetailPage() {
             
         } catch (error) {
             console.error("❌ 이미지 캡처 중 오류 발생:", error);
+            alert("이미지 캡처 중 오류가 발생했습니다. 브라우저 호환성 또는 CSS 설정을 확인해 주세요.");
         }
     };
     
@@ -496,11 +510,11 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            {/* ⭐️ [수정] Download 아이콘에 캡처 함수 연결 ⭐️ */}
+                            {/* ⭐️ Download 아이콘에 캡처 함수 연결 ⭐️ */}
                             <button className={timetableStyles.actionButton} onClick={handleCaptureAndDownload}>
                                 <img src={download} alt="이미지 캡처 및 다운로드" />
                             </button>
-                            {/* Refresh 버튼에 수정된 handleRefresh 연결 */}
+                            {/* Refresh 버튼 (로컬 선택 초기화) */}
                             <button className={timetableStyles.actionButton} onClick={handleRefresh}>
                                 <img src={refresh} alt="되돌리기"/>
                             </button>
@@ -510,7 +524,7 @@ export default function TimetableDetailPage() {
 
                 {currentDayIndex !== -1 && (
                 <div className={timetableStyles.timetableScrollWrapper}>
-                    {/* ⭐️ [추가] 캡처를 위한 ID 부여 ⭐️ */}
+                    {/* ⭐️ [캡처 대상] 순수한 TimetableGrid 콘텐츠 전체를 포함하는 영역 ⭐️ */}
                     <div id="timetable-capture-area" className={timetableStyles.scheduleArea}>
                         <TimetableGrid 
                             stageMap={schedulesByStage.stageMap} 

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,24 +1,75 @@
-import { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+// src/pages/timetable/TimetableDetailPage.tsx
+
+import { useState, useEffect, useMemo } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import leftarrow from "../../assets/timetable/arrow-left.svg"
 
-// CSS 모듈 (임시)
-import detailStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
-
-// 타입 및 Mock 데이터 import (경로는 실제 프로젝트 구조에 맞게 조정하세요)
-import { FestivalDetailData } from "../../types/timetable"; 
-import { mockFestivalDetail } from "../../data/mockTimetableDetail"; 
+// ⭐️ CSS 모듈명 변경: detailStyles -> timetableStyles ⭐️
+import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
 
 
-const TimetableDetailPage = () => {
+// 1. 임시 타입 정의
+interface FestivalDetailData {
+  festivalId: number;
+  festivalTitle: string;
+  days: { date: string; stages: { stageName: string; }[] }[];
+}
+
+// 2. 임시 Mock 데이터를 Map 형태로 확장합니다. 
+const MockFestivalDetails: Record<number, FestivalDetailData> = {
+    1: {
+        festivalId: 1, 
+        festivalTitle: "그랜드 민트 페스티벌 2025",
+        days: [
+            { date: "2025.12.20", stages: [{ stageName: "Mint Breeze Stage" }] }, 
+            { date: "2025.12.21", stages: [{ stageName: "Loving Forest Garden" }] }
+        ],
+    },
+    2: {
+        festivalId: 2,
+        festivalTitle: "COUNTDOWN FANTASY 2025-2026",
+        days: [
+            { date: "2025.12.30", stages: [{ stageName: "Fantasy Stage" }] }, 
+            { date: "2025.12.31", stages: [{ stageName: "New Year Stage" }] }
+        ],
+    },
+    3: { 
+        festivalId: 3, 
+        festivalTitle: "COUNTDOWN FANTASY 2025-2026 (추천)", 
+        days: [{ date: "2025.12.20", stages: [{ stageName: "Stage A" }] }] 
+    },
+    4: { 
+        festivalId: 4, 
+        festivalTitle: "DMZ 피스트레인 (추천)", 
+        days: [{ date: "2025.10.18", stages: [{ stageName: "Stage B" }] }] 
+    },
+    7: { 
+        festivalId: 7, 
+        festivalTitle: "더 많은 페스티벌 1", 
+        days: [{ date: "2025.12.20", stages: [{ stageName: "Main Stage" }] }] 
+    },
+};
+
+// 3. 모드 타입 정의
+type TimetableMode = 'customize' | 'my' | 'view'; 
+
+export default function TimetableDetailPage() {
     
     const navigate = useNavigate();
-    // URL 파라미터에서 페스티벌 ID를 문자열로 가져옵니다.
+    const location = useLocation();
     const { id: festivalId } = useParams<{ id: string }>(); 
 
-    // 데이터 및 로딩 상태 관리
     const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
+    
+    const [currentDayIndex, setCurrentDayIndex] = useState(0);
+
+    // 4. 현재 모드 계산 (URL 분석)
+    const currentMode: TimetableMode = useMemo(() => {
+        if (location.pathname.includes('/my/')) return 'my';
+        if (location.pathname.includes('/customize/')) return 'customize';
+        return 'view'; 
+    }, [location.pathname]);
 
     const handleGoBack = () => {
         navigate(-1); 
@@ -26,8 +77,7 @@ const TimetableDetailPage = () => {
 
     // 데이터 로딩 (API 호출 시뮬레이션)
     useEffect(() => {
-        // ID가 없거나 유효하지 않으면 로드하지 않습니다.
-        if (!festivalId) {
+        if (!festivalId) { 
             setIsLoading(false);
             return;
         }
@@ -35,18 +85,28 @@ const TimetableDetailPage = () => {
         async function fetchTimetableDetail() {
             setIsLoading(true);
             try {
-                // 500ms 딜레이를 주어 네트워크 로딩을 시뮬레이션
                 await new Promise(resolve => setTimeout(resolve, 500)); 
                 
-                // Mocking: ID가 일치하는지 확인
-                if (parseInt(festivalId) === mockFestivalDetail.festivalId) {
-                    setDetailData(mockFestivalDetail);
-                } else {
-                    setDetailData(null); // 해당 ID의 데이터가 없음
+                let dataToLoad: FestivalDetailData | null = null;
+                const idNum = parseInt(festivalId!); 
+                const baseData = MockFestivalDetails[idNum];
+
+                if (baseData) {
+                    if (currentMode === 'customize') {
+                        dataToLoad = baseData;
+                    } else if (currentMode === 'my') {
+                        dataToLoad = { 
+                            ...baseData,
+                            festivalTitle: baseData.festivalTitle + " (내 커스텀)"
+                        }; 
+                    }
+                    setCurrentDayIndex(0); 
                 }
+                
+                setDetailData(dataToLoad); 
 
             } catch (error) {
-                console.error(`[ID:${festivalId}] 상세 타임테이블 로드 오류:`, error);
+                console.error(`[${currentMode} Mode] 상세 타임테이블 로드 오류:`, error);
                 setDetailData(null); 
             } finally {
                 setIsLoading(false);
@@ -54,52 +114,82 @@ const TimetableDetailPage = () => {
         }
 
         fetchTimetableDetail();
-    }, [festivalId]); 
+    }, [festivalId, currentMode]); 
 
     
     // --- 로딩/에러 처리 UI ---
     if (isLoading) {
-        return <div className={detailStyles.pageContainer}>타임테이블 로딩 중...</div>;
+        // ⭐️ 클래스명 변경 적용 ⭐️
+        return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;
     }
 
     if (!detailData) {
-        return <div className={detailStyles.pageContainer}>요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
+        // ⭐️ 클래스명 변경 적용 ⭐️
+        return <div className={timetableStyles.pageContainer}>요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
     }
+
+    // 현재 선택된 날짜의 데이터
+    const selectedDayData = detailData.days[currentDayIndex];
 
     // --- 메인 UI 렌더링 ---
     return (
-        <div className={detailStyles.pageContainer}>
+        // ⭐️ 클래스명 변경 적용 ⭐️
+        <div className={timetableStyles.pageContainer}>
             
-            {/* 1. 상단 헤더 영역 (뒤로 가기 버튼, 타이틀) */}
-            <header className={detailStyles.header}>
+            <header className={timetableStyles.header}>
                 <button 
-                    className={detailStyles.backButton}
+                    // ⭐️ 클래스명 변경 적용 ⭐️
+                    className={timetableStyles.backButton}
                     onClick={handleGoBack}
                 >
                     <img src={leftarrow} alt="뒤로 가기" />
                 </button>
                 
-                {/* API 응답에서 받은 제목 표시 */}
-                <h1 className={detailStyles.pageTitle}>
-                    {detailData.festivalTitle}
+                <h1 className={timetableStyles.pageTitle}>
+                    {detailData.festivalTitle} 
                 </h1>
-                
-                {/* 여기에 커스텀 저장 등의 버튼이 들어갈 수 있습니다. */}
+                <div className={timetableStyles.emptyBox}></div>
+            
             </header>
 
-            <main className={detailStyles.mainContent}>
+            <main className={timetableStyles.mainContent}>
                 
-                {/* 2. 날짜 선택 탭 컴포넌트가 위치할 영역 */}
-                <p>여기에 날짜 탭 컴포넌트를 사용하여 날짜를 선택합니다.</p>
+                {/* ⭐️ 1. 날짜 탭 UI ⭐️ */}
+                {detailData.days.length > 0 && (
+                    <div className={timetableStyles.dayTabs}>
+                        {detailData.days.map((day, index) => (
+                            <button
+                                key={index}
+                                // ⭐️ 클래스명 변경 적용 ⭐️
+                                className={`${timetableStyles.dayTab} ${
+                                    index === currentDayIndex ? timetableStyles.active : ''
+                                }`}
+                                onClick={() => setCurrentDayIndex(index)}
+                            >
+                                {day.date}
+                            </button>
+                        ))}
+                    </div>
+                )}
                 
-                {/* 3. 실제 타임테이블 (선택된 날짜의 일정) 컴포넌트가 위치할 영역 */}
-                <p>선택된 날짜: {detailData.days[0].date}</p>
-                <p>총 {detailData.days.length}일 동안 진행되는 페스티벌입니다.</p>
-                
+                {/* ⭐️ 2. 선택된 날짜의 스테이지/일정 영역 ⭐️ */}
+                <div className={timetableStyles.scheduleArea}>
+                    
+                    <h3>{selectedDayData.date} 일정</h3>
+                    
+                    {/* TODO: 여기에 스테이지 필터와 실제 타임테이블 목록이 들어갑니다. */}
+                    <div style={{ marginTop: '10px', padding: '10px', border: '1px solid #ccc' }}>
+                        <p>선택된 날짜의 스테이지 수: {selectedDayData.stages.length}</p>
+                        <ul>
+                            {selectedDayData.stages.map((stage, index) => (
+                                <li key={index}>{stage.stageName}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                </div>
             </main>
 
         </div>
     );
-};
-
-export default TimetableDetailPage;
+}

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableDetailPage.tsx
+// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 완료 버전)
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -14,7 +14,7 @@ import api from "../../api/api"; // Axios 인스턴스
 // ⭐️ Kopis API 응답 타입 ⭐️
 export interface KopisFestivalItem {
    id: number; 
-  mt20id: string; // <-- 이 값을 사용합니다.
+  mt20id: string; 
   prfnm: string; 
   prfpdfrom: string; 
   prfpdto: string; 
@@ -37,13 +37,34 @@ export interface KopisFestivalItem {
   fesLinks: { relatenm: string; relateurl: string; }[];
   artistPics: { date: string; relatenm: string; url: string; }[];
 }
+
+// ⭐️ 서버의 /festivals/{mt20id}/detail 응답 타입 정의 ⭐️
+export interface CustomDetailAPIItem {
+    mt20id: string; 
+    prfnm: string; 
+    hasCustom: boolean;
+    slots: { 
+        date: string; 
+        stageId: string; 
+        stageName: string; 
+        stageOrder: number; 
+        artist: string; 
+        start: { hour: number; minute: number; second: number; nano: number; } | string; 
+        end: { hour: number; minute: number; second: number; nano: number; } | string; 
+        minutes: number; 
+        img: string | null; 
+        note: string | null; 
+        inverted?: boolean; // 사용자가 선택했는지 여부
+    }[];
+}
+
 export interface ScheduleItem { 
   date: string; stageId: string; stageName: string; stageOrder: number; 
   artist: string; start: string; end: string; minutes: number; 
   img: string | null; note: string | null; isCustomized?: boolean; 
 }
 interface DayScheduleData { date: string; schedules: ScheduleItem[]; }
-// ⭐️ mt20id 필드 추가
+
 interface FestivalDetailData { 
     festivalId: number; 
     mt20id: string; // API 응답에서 받은 고유 ID
@@ -51,7 +72,6 @@ interface FestivalDetailData {
     days: DayScheduleData[]; 
 }
 
-// ⭐️ 스케줄 아이템의 고유 키를 생성하는 헬퍼 함수
 const createScheduleKey = (s: ScheduleItem) => `${s.date}-${s.stageId}-${s.artist}-${s.start}`;
 
 const formatDayAndDayOfWeek = (dateString: string): string => {
@@ -65,7 +85,7 @@ const formatDayAndDayOfWeek = (dateString: string): string => {
 
 type TimetableMode = 'customize' | 'my' | 'view'; 
 
-// API 호출 및 데이터 변환 함수 
+// ⭐️ 1. Kopis API 호출 및 데이터 변환 함수 (기본 데이터 로드) ⭐️
 async function fetchAndProcessTimetableDetail(
     festivalId: string | undefined, 
     setCurrentDayIndex: (index: number) => void, 
@@ -81,8 +101,9 @@ async function fetchAndProcessTimetableDetail(
     setIsLoading(true);
     const idNum = parseInt(festivalId, 10);
     let processedData: FestivalDetailData | null = null;
-
+    
     try {
+        // Kopis API 엔드포인트 사용
         const response = await api.get(`/kopis/performances/festivals?festivalId=${idNum}`); 
         
         const rawData = response.data.data || response.data;
@@ -97,7 +118,6 @@ async function fetchAndProcessTimetableDetail(
             return null;
         }
         
-        // ⭐️ (추가) ⭐️ mt20id가 누락되었을 경우를 대비해 festivalId를 폴백으로 사용
         const mt20idValue = apiData.mt20id || festivalId;
 
         const schedulesByDateMap: Record<string, ScheduleItem[]> = {};
@@ -105,30 +125,19 @@ async function fetchAndProcessTimetableDetail(
         apiData.slots.forEach(slot => {
             const dateString = slot.date;
             
-            let startString = "00:00:00";
-            let endString = "00:00:00";
+            const timeObjToString = (time: any) => {
+                const hour = time.hour ?? 0;
+                const minute = time.minute ?? 0;
+                return `${hour.toString().padStart(2,'0')}:${minute.toString().padStart(2,'0')}:00`;
+            };
 
-            if (typeof slot.start === 'string') {
-                startString = slot.start;
-            } else if (slot.start && typeof slot.start === 'object') {
-                const startHour = slot.start.hour ?? 0;
-                const startMinute = slot.start.minute ?? 0;
-                startString = `${startHour.toString().padStart(2,'0')}:${startMinute.toString().padStart(2,'0')}:00`;
-            }
-            
-            if (typeof slot.end === 'string') {
-                endString = slot.end;
-            } else if (slot.end && typeof slot.end === 'object') {
-                const endHour = slot.end.hour ?? 0;
-                const endMinute = slot.end.minute ?? 0;
-                endString = `${endHour.toString().padStart(2,'0')}:${endMinute.toString().padStart(2,'0')}:00`;
-            }
+            const startString = typeof slot.start === 'string' ? slot.start : timeObjToString(slot.start);
+            const endString = typeof slot.end === 'string' ? slot.end : timeObjToString(slot.end);
 
             const scheduleItem: ScheduleItem = {
                 date: slot.date,
                 stageId: slot.stageId,
                 stageName: slot.stageName,
-                // 주의: slot.stageOrder는 이미 Number 타입으로 가정되지만, 아래에서 Number()로 한번 더 변환하여 안전성 확보
                 stageOrder: slot.stageOrder, 
                 artist: slot.artist,
                 start: startString, 
@@ -149,7 +158,7 @@ async function fetchAndProcessTimetableDetail(
 
         processedData = {
             festivalId: idNum,
-            mt20id: mt20idValue, // ⭐️ API에서 가져온 mt20id 저장
+            mt20id: mt20idValue,
             festivalTitle: apiData.prfnm,
             days: processedDays
         };
@@ -164,6 +173,46 @@ async function fetchAndProcessTimetableDetail(
         setIsLoading(false); 
     }
     return processedData;
+}
+
+// ⭐️ 2. 사용자 커스텀 슬롯만 가져오는 함수 ⭐️
+async function fetchCustomSlots(
+    mt20id: string,
+    setActiveScheduleKeys: (keys: Set<string>) => void
+): Promise<void> {
+    const API_URL = `/festivals/${mt20id}/detail`;
+    
+    try {
+        const response = await api.get(API_URL);
+        const apiData: CustomDetailAPIItem = response.data.data || response.data;
+        
+        const initialActiveKeys = new Set<string>();
+
+        if (apiData.hasCustom && apiData.slots) {
+            apiData.slots.forEach(slot => {
+                 const timeObjToString = (time: any) => {
+                    const hour = time.hour ?? 0;
+                    const minute = time.minute ?? 0;
+                    return `${hour.toString().padStart(2,'0')}:${minute.toString().padStart(2,'0')}:00`;
+                };
+
+                const startString = typeof slot.start === 'string' ? slot.start : timeObjToString(slot.start);
+
+                if (slot.inverted === true) {
+                     // ScheduleItem의 키 생성 방식과 동일하게 구성
+                     const scheduleKey = `${slot.date}-${slot.stageId}-${slot.artist}-${startString}`;
+                     initialActiveKeys.add(scheduleKey);
+                }
+            });
+        }
+        
+        setActiveScheduleKeys(initialActiveKeys);
+        console.log(`✅ [GET ${API_URL}] 사용자 커스텀 슬롯 로드 성공. ${initialActiveKeys.size}개 활성화.`);
+
+    } catch (error) {
+        console.error(`❌ 사용자 커스텀 슬롯 (${API_URL}) 로드 중 오류 발생:`, error);
+        setActiveScheduleKeys(new Set()); 
+    }
 }
 
 
@@ -195,12 +244,11 @@ export default function TimetableDetailPage() {
         });
         
         console.log("--- Schedule Toggled ---");
-        console.log("Date:", schedule.date);
         console.log("Artist:", schedule.artist);
-        console.log("Stage Order:", schedule.stageOrder);
         console.log("Inverted/Selected (New State):", newStateIsActive); 
         console.log("------------------------");
     };
+
 
     const currentMode: TimetableMode = useMemo(() => {
         if (location.pathname.includes('/my/')) return 'my';
@@ -208,48 +256,44 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
     
-    // ⭐️ (userId 제거) 페이로드: mt20id와 invertedSlots만 포함 ⭐️
+    // ⭐️ [수정] getPayloadAndCheckSelection 함수: 현재 날짜가 아닌 페스티벌 전체 스케줄을 포함하도록 수정 ⭐️
     const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
-        // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청을 할 수 없음
-        if (!detailData || currentDayIndex === -1 || !detailData.mt20id) return { payload: null, hasSelections: false };
+        if (!detailData || !detailData.mt20id) return { payload: null, hasSelections: false };
         
-        const currentDaySchedules = detailData.days[currentDayIndex]?.schedules || [];
-        let hasSelections = false;
+        // ⭐️ [수정] currentDayIndex 대신, detailData.days 전체를 순회하여 모든 스케줄을 모읍니다. ⭐️
+        let allFestivalSchedules: ScheduleItem[] = [];
+        detailData.days.forEach(day => {
+            allFestivalSchedules = allFestivalSchedules.concat(day.schedules);
+        });
+        
+        const invertedSlots: any[] = [];
+        let finalHasSelections = false;
 
-        // 1. 모든 스케줄을 매핑하여 inverted 상태를 포함한 슬롯 객체 생성
-        const allSlots = currentDaySchedules.map(schedule => {
+        // ⭐️ [수정] 페스티벌 전체 스케줄(allFestivalSchedules)을 순회합니다. ⭐️
+        allFestivalSchedules.forEach(schedule => {
             const key = createScheduleKey(schedule);
             const isInverted = activeScheduleKeys.has(key); 
             
             if (isInverted) {
-                hasSelections = true;
+                finalHasSelections = true; // 하나라도 선택되면 true
+                
+                // 선택된 슬롯만 페이로드에 포함합니다.
+                invertedSlots.push({
+                    date: schedule.date,
+                    stageOrder: Number(schedule.stageOrder), 
+                    artist: schedule.artist,
+                    inverted: isInverted 
+                });
             }
-            
-            return {
-                date: schedule.date,
-                // ⭐️ stageOrder를 Number() 함수로 감싸서 확실히 숫자 타입으로 전송 (백엔드 타입 오류 방지) ⭐️
-                stageOrder: Number(schedule.stageOrder), 
-                artist: schedule.artist,
-                inverted: isInverted 
-            };
         });
-
-        // 2. inverted: true 인 항목만 필터링하여 전송 
-        const invertedSlots = allSlots.filter(slot => slot.inverted === true);
         
-        // 필터링 후에도 선택된 항목이 있는지 다시 확인
-        const finalHasSelections = invertedSlots.length > 0;
-        
-        // ⭐️ userId 필드 제거 ⭐️
         const payload: { mt20id: string; invertedSlots: any[] } = {
             mt20id: detailData.mt20id, 
-            invertedSlots: invertedSlots
+            invertedSlots: invertedSlots // 이제 이 배열은 모든 날짜의 선택된 슬롯을 포함합니다.
         };
         
-        // 선택된 항목이 없으면 payload가 null은 아니지만, hasSelections가 false임을 반환
         return { payload, hasSelections: finalHasSelections };
     };
-
 
     const allSchedules = useMemo(() => {
         if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) return [];
@@ -271,6 +315,8 @@ export default function TimetableDetailPage() {
         return { stageMap, stageNames };
     }, [allSchedules]);
 
+
+    // ⭐️ 1. Kopis API 호출 (기본 데이터 로드) ⭐️
     useEffect(() => {
         if (festivalId) {
             fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
@@ -280,56 +326,62 @@ export default function TimetableDetailPage() {
         }
     }, [festivalId]);
     
-    // ⭐️ 핵심 저장 로직. 성공/건너뛰면 true, 실패하면 false 반환
+    // ⭐️ 2. detailData 로드 후, 'my' 모드일 때만 커스텀 슬롯 API 호출 ⭐️
+    useEffect(() => {
+        if (detailData && detailData.mt20id && currentMode === 'my') {
+            fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
+        } 
+    }, [detailData, currentMode]); 
+
+    // ⭐️ [수정] saveTimetableData 함수: 선택 여부와 관계없이 POST 요청을 보내도록 수정 ⭐️
     const saveTimetableData = async (): Promise<boolean> => { 
         
-        // ❌ userId 확보 및 검증 로직 완전히 제거 ❌
-        
-        const { payload, hasSelections } = getPayloadAndCheckSelection();
+        const { payload, hasSelections } = getPayloadAndCheckSelection(); // 이제 페스티벌 전체의 선택 상태를 가져옴
 
-        // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청 건너뛰기
-        if (!payload) {
-            console.log("⚠️ 저장할 데이터가 준비되지 않았습니다. (mt20id 누락 또는 데이터 로딩 문제)");
-            return true;
+        if (!payload || !payload.mt20id) {
+            console.error("⚠️ 저장할 데이터가 준비되지 않았습니다. (mt20id 누락)");
+            return false;
         }
         
-        if (!hasSelections) {
-            console.log("ℹ️ 선택된 스케줄이 없어 서버에 저장 요청을 건너뜁니다.");
-            return true; 
-        }
+        // ⭐️ [수정] 선택된 슬롯이 0개일 때도 POST 요청을 보내어 삭제 명령을 서버에 전달합니다. ⭐️
+        // (이전 코드에서는 hasSelections가 false일 때 return true로 빠져나갔음)
 
         const mt20id = payload.mt20id;
         const API_ENDPOINT = `/festivals/${mt20id}/custom-slots`; 
         const HTTP_METHOD = 'POST'; 
 
-        console.log(`💾 Final Payload Ready for ${HTTP_METHOD} to ${API_ENDPOINT}:`, payload);
-        console.log('⭐️ RAW JSON STRING:', JSON.stringify(payload)); 
+        if (!hasSelections) {
+             console.log("ℹ️ 선택된 스케줄이 없어, 커스텀 슬롯 삭제 요청을 서버에 보냅니다. (빈 배열 POST)");
+        } else {
+            console.log(`💾 ${payload.invertedSlots.length}개 슬롯 저장 요청을 보냅니다.`);
+        }
 
         try {
-            // ⭐️⭐️ api.post 호출 시, userId 쿼리 파라미터 전달 로직 제거 ⭐️⭐️
             const response = await api.post(API_ENDPOINT, payload); 
 
-            console.log(`✅ 타임테이블 저장 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, response.data);
-            alert("나의 타임테이블이 성공적으로 서버에 저장되었습니다!");
+            console.log(`✅ 타임테이블 저장/삭제 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, response.data);
+            alert(hasSelections ? "나의 타임테이블이 성공적으로 서버에 저장되었습니다!" : "나의 타임테이블에서 성공적으로 삭제되었습니다.");
             return true;
 
         } catch (error) {
             const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
-            // ⭐️ 에러 발생 시 로그에서 userId 관련 정보 제거 ⭐️
-            console.error(`❌ 타임테이블 저장 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error); 
-            alert(`타임테이블 저장 중 오류가 발생했습니다: ${errorMessage}`);
+            console.error(`❌ 타임테이블 저장/삭제 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error); 
+            alert(`타임테이블 저장/삭제 중 오류가 발생했습니다: ${errorMessage}`);
             return false;
         }
     };
     
-    // ⭐️ 뒤로 가기 버튼 클릭 시 저장 로직이 포함된 handleGoBack 연결
+    // 뒤로 가기 버튼 클릭 시 저장 로직이 포함된 handleGoBack 연결
     const handleGoBack = async () => {
-        const saveSuccessful = await saveTimetableData();
-
-        if (saveSuccessful) {
-            navigate(-1);
+        if (currentMode === 'customize' || currentMode === 'my') { 
+            const saveSuccessful = await saveTimetableData();
+             if (saveSuccessful) {
+                navigate(-1);
+            } else {
+                console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
+            }
         } else {
-            console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
+             navigate(-1);
         }
     };
     
@@ -341,14 +393,14 @@ export default function TimetableDetailPage() {
         if (festivalId) fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
         else { setDetailData(null); setIsLoading(false); }
     };
-
+    
+    // ⭐️ ⭐️ [오류 수정] handleDaySelect 함수를 컴포넌트 내부로 이동 ⭐️ ⭐️
     const handleDaySelect = (index: number) => { 
         setCurrentDayIndex(index); 
         setIsDropdownOpen(false); 
     };
 
     if (isLoading) return <div className={timetableStyles.pageContainer}>데이터를 불러오는 중입니다...</div>;
-    // detailData.mt20id도 확인
     if (!detailData || detailData.days.length === 0 || !detailData.mt20id) return <div className={timetableStyles.pageContainer}>존재하지 않는 페스티벌이거나 데이터가 없습니다. (ID 누락 확인)</div>;
     if (currentDayIndex === -1 || !detailData.days[currentDayIndex]) return <div className={timetableStyles.pageContainer}>날짜 데이터를 준비 중입니다...</div>;
 
@@ -361,7 +413,6 @@ export default function TimetableDetailPage() {
     return (
         <div className={timetableStyles.pageContainer}>
             <header className={timetableStyles.header}>
-                {/* ⭐️ 뒤로 가기 버튼에 저장 로직이 포함된 handleGoBack 연결 */}
                 <button className={timetableStyles.backButton} onClick={handleGoBack}>
                     <img src={leftarrow} alt="뒤로 가기" />
                 </button>
@@ -390,7 +441,6 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            {/* 다운로드 버튼은 기능이 제거됨 */}
                             <button className={timetableStyles.actionButton} onClick={() => console.log("저장 기능이 뒤로 가기 버튼으로 이동했습니다.")}>
                                 <img src={download} alt="저장 기능 제거됨"/>
                             </button>

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,8 +1,11 @@
-// src/pages/timetable/TimetableDetailPage.tsx (Alert 및 모달 기능 완전히 제거)
+// src/pages/timetable/TimetableDetailPage.tsx (Refresh 로직 수정 및 캡처 기능 추가)
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import type { Location } from "react-router-dom"; 
+// ⭐️ [추가] html2canvas 임포트
+import html2canvas from 'html2canvas';
+
 import leftarrow from "../../assets/timetable/arrow-left.svg";
 import downarrow from "../../assets/timetable/arrow-down.svg";
 import download from "../../assets/timetable/download.svg";
@@ -236,6 +239,7 @@ export default function TimetableDetailPage() {
     const [currentDayIndex, setCurrentDayIndex] = useState(-1);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
     
+    // 사용자가 선택한 스케줄 키를 저장하는 상태
     const [activeScheduleKeys, setActiveScheduleKeys] = useState<Set<string>>(new Set());
     
     const handleScheduleToggle = (schedule: ScheduleItem) => {
@@ -334,6 +338,8 @@ export default function TimetableDetailPage() {
     
     // ⭐️ 2. detailData 로드 후, 커스텀 슬롯 API 호출 ⭐️
     useEffect(() => {
+        // detailData 로드 후, 'my' 또는 'customize' 모드에서만 서버에 저장된 커스텀 슬롯을 불러옵니다.
+        // 이 로직 때문에, API 재호출을 포함한 기존 Refresh 함수는 로컬 초기화가 덮어씌워지는 문제가 있었습니다.
         if (detailData && detailData.mt20id && (currentMode === 'my' || currentMode === 'customize')) { 
             fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
         } else if (currentMode === 'view') {
@@ -386,6 +392,7 @@ export default function TimetableDetailPage() {
         if (currentMode === 'customize' || currentMode === 'my') { 
             const saveSuccessful = await saveTimetableData();
              if (saveSuccessful) {
+                // 저장 성공 시에만 뒤로 이동
                 navigate(-1);
             } else {
                 // 저장 실패 시 사용자에게 알림 없이 콘솔에만 기록하고 이동 취소
@@ -396,13 +403,51 @@ export default function TimetableDetailPage() {
         }
     };
     
+    // ⭐️⭐️ [FIX] handleRefresh 수정: 기본 데이터 재로드 로직 제거 ⭐️⭐️
     const handleRefresh = () => {
-        console.log("🔄 Refreshing data from API.");
-        setCurrentDayIndex(-1); 
-        setIsDropdownOpen(false);
-        setActiveScheduleKeys(new Set()); 
-        if (festivalId) fetchAndProcessTimetableDetail(festivalId, setCurrentDayIndex, setDetailData, setIsLoading);
-        else { setDetailData(null); setIsLoading(false); }
+        // 변경: 현재 로컬에서 선택된 내용만 즉시 모두 해제(false)하도록 수정합니다.
+        console.log("🔄 Refresh 버튼 클릭: 현재 로컬에서 선택된 모든 스케줄을 초기화합니다.");
+        
+        setActiveScheduleKeys(new Set()); // 모든 선택 상태를 빈 Set으로 초기화
+        setIsDropdownOpen(false); // 드롭다운 닫기
+    };
+
+    // ⭐️⭐️ [추가] 캡처 로직 (Download 버튼에 연결) ⭐️⭐️
+    const handleCaptureAndDownload = async () => {
+        console.log("📸 이미지 캡처 시작...");
+        
+        // TimetableGrid를 감싸는 고유 ID를 가진 요소
+        const inputElement = document.getElementById('timetable-capture-area');
+
+        if (!inputElement) {
+            console.error("⚠️ 캡처 대상 요소를 찾을 수 없습니다. (ID: timetable-capture-area)");
+            return;
+        }
+        
+        // 캡처 실행 (긴 콘텐츠를 위해 scroll, scale 옵션 사용)
+        try {
+            const canvas = await html2canvas(inputElement, {
+                useCORS: true, // 외부 이미지 (포스터 등) 로드를 위해 필수
+                scale: 2,       // 고해상도 출력을 위해 스케일 조정 (선택 사항)
+                // 긴 타임테이블이 컨테이너 내부에 스크롤되어도 전체를 캡처하도록 설정
+                windowWidth: inputElement.scrollWidth,
+                windowHeight: inputElement.scrollHeight,
+            });
+
+            // 다운로드 링크 생성 및 클릭
+            const image = canvas.toDataURL('image/png');
+            const a = document.createElement('a');
+            a.href = image;
+            a.download = `${detailData?.festivalTitle || 'Timetable'}_${formatDayAndDayOfWeek(selectedDayData.date).replace(/[\.()]/g, '')}.png`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+
+            console.log("✅ 이미지 다운로드 성공.");
+            
+        } catch (error) {
+            console.error("❌ 이미지 캡처 중 오류 발생:", error);
+        }
     };
     
     const handleDaySelect = (index: number) => { 
@@ -451,10 +496,11 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            {/* 저장 버튼은 기능이 뒤로 가기에 통합되었고, 모달/alert이 제거되었으므로 콘솔 로그만 남깁니다. */}
-                            <button className={timetableStyles.actionButton} onClick={() => console.log("저장 기능이 뒤로 가기 버튼에 통합되었으며, 모든 알림 창이 제거되었습니다.")}>
-                                <img src={download} alt="저장 기능" />
+                            {/* ⭐️ [수정] Download 아이콘에 캡처 함수 연결 ⭐️ */}
+                            <button className={timetableStyles.actionButton} onClick={handleCaptureAndDownload}>
+                                <img src={download} alt="이미지 캡처 및 다운로드" />
                             </button>
+                            {/* Refresh 버튼에 수정된 handleRefresh 연결 */}
                             <button className={timetableStyles.actionButton} onClick={handleRefresh}>
                                 <img src={refresh} alt="되돌리기"/>
                             </button>
@@ -463,7 +509,9 @@ export default function TimetableDetailPage() {
                 )}
 
                 {currentDayIndex !== -1 && (
-                <div className={timetableStyles.timetableScrollWrapper}><div className={timetableStyles.scheduleArea}>
+                <div className={timetableStyles.timetableScrollWrapper}>
+                    {/* ⭐️ [추가] 캡처를 위한 ID 부여 ⭐️ */}
+                    <div id="timetable-capture-area" className={timetableStyles.scheduleArea}>
                         <TimetableGrid 
                             stageMap={schedulesByStage.stageMap} 
                             allSchedules={allSchedules} 
@@ -471,7 +519,8 @@ export default function TimetableDetailPage() {
                             onScheduleToggle={handleScheduleToggle}
                             activeScheduleKeys={activeScheduleKeys}
                         />
-                    </div></div>
+                    </div>
+                </div>
                     
                 )}
                 

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -208,7 +208,7 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
     
-    // ⭐️ (수정된 함수) ⭐️ 페이로드 생성 시 detailData.mt20id 사용, 타입 캐스팅 및 필터링 적용
+    // ⭐️ (최종 안전 수정 함수) ⭐️ 페이로드 생성 시 mt20id 중복 방지 및 필터링 적용
     const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
         // detailData.mt20id가 없거나 데이터 준비가 안됐으면 저장 요청을 할 수 없음
         if (!detailData || currentDayIndex === -1 || !detailData.mt20id) return { payload: null, hasSelections: false };
@@ -227,20 +227,21 @@ export default function TimetableDetailPage() {
             
             return {
                 date: schedule.date,
-                // ⭐️⭐️ 수정 1: stageOrder를 Number() 함수로 감싸서 확실히 숫자 타입으로 전송 (백엔드 타입 오류 방지) ⭐️⭐️
+                // ⭐️ stageOrder를 Number() 함수로 감싸서 확실히 숫자 타입으로 전송 (백엔드 타입 오류 방지) ⭐️
                 stageOrder: Number(schedule.stageOrder), 
                 artist: schedule.artist,
                 inverted: isInverted 
             };
         });
 
-        // 2. ⭐️⭐️ 수정 2: inverted: true 인 항목만 필터링하여 전송 (서버가 수정 대상만 받기를 기대할 경우 오류 방지) ⭐️⭐️
+        // 2. inverted: true 인 항목만 필터링하여 전송 
         const invertedSlots = allSlots.filter(slot => slot.inverted === true);
         
         // 필터링 후에도 선택된 항목이 있는지 다시 확인
         const finalHasSelections = invertedSlots.length > 0;
         
-        const payload = {
+        // ⭐️⭐️ 수정 1: 객체를 단순하게 만들어 mt20id 중복 가능성을 제거 ⭐️⭐️
+        const payload: { mt20id: string; invertedSlots: any[] } = {
             mt20id: detailData.mt20id, 
             invertedSlots: invertedSlots
         };
@@ -299,6 +300,8 @@ export default function TimetableDetailPage() {
         const HTTP_METHOD = 'PUT'; 
 
         console.log(`💾 Final Payload Ready for ${HTTP_METHOD} to ${API_ENDPOINT}:`, payload);
+        // ⭐️⭐️ 추가 로그: JSON.stringify로 실제 전송될 문자열 확인 (디버깅용) ⭐️⭐️
+        console.log('⭐️ RAW JSON STRING:', JSON.stringify(payload)); 
 
         try {
             const response = await api.put(API_ENDPOINT, payload); 

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableDetailPage.tsx (최종 수정 완료 버전 - my-detail 적용)
+// src/pages/timetable/TimetableDetailPage.tsx (Alert 및 모달 기능 완전히 제거)
 
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
@@ -48,7 +48,6 @@ export interface KopisFestivalItem {
 }
 
 // ⭐️ 서버의 /festivals/{mt20id}/my-detail 응답 타입 정의 ⭐️
-// (사용자님이 제공해주신 응답 스키마와 일치하도록 반영)
 export interface CustomDetailAPIItem {
     mt20id: string; 
     prfnm: string; 
@@ -64,7 +63,7 @@ export interface CustomDetailAPIItem {
         stageName: string; 
         stageOrder: number; 
         artist: string; 
-        start: TimeObject | string; // TimeObject 또는 string 처리
+        start: TimeObject | string; 
         end: TimeObject | string; 
         minutes: number; 
         img: string | null; 
@@ -196,24 +195,19 @@ async function fetchCustomSlots(
     mt20id: string,
     setActiveScheduleKeys: (keys: Set<string>) => void
 ): Promise<void> {
-    // ⭐️ API URL 변경 적용: detail -> my-detail (요청하신 대로) ⭐️
     const API_URL = `/festivals/${mt20id}/my-detail`; 
     
     try {
         const response = await api.get(API_URL);
-        // 응답 데이터가 배열이 아닌 CustomDetailAPIItem 형식이라고 가정합니다.
         const apiData: CustomDetailAPIItem = response.data.data || response.data; 
         
         const initialActiveKeys = new Set<string>();
 
-        // hasCustom이 true이고 slots가 존재하며, slots가 배열인지 확인
         if (apiData.hasCustom && Array.isArray(apiData.slots)) {
             apiData.slots.forEach(slot => {
                 const startString = timeToTimeString(slot.start); // 헬퍼 함수 사용
                 
                 if (slot.inverted === true) {
-                     // ScheduleItem의 키 생성 방식과 동일하게 구성
-                     // slot.artist가 없을 경우를 대비해 artist 필드가 있음을 확인
                      if (slot.artist) {
                          const scheduleKey = `${slot.date}-${slot.stageId}-${slot.artist}-${startString}`;
                          initialActiveKeys.add(scheduleKey);
@@ -241,7 +235,7 @@ export default function TimetableDetailPage() {
     const [isLoading, setIsLoading] = useState(true);
     const [currentDayIndex, setCurrentDayIndex] = useState(-1);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-
+    
     const [activeScheduleKeys, setActiveScheduleKeys] = useState<Set<string>>(new Set());
     
     const handleScheduleToggle = (schedule: ScheduleItem) => {
@@ -267,19 +261,11 @@ export default function TimetableDetailPage() {
 
 
     const currentMode: TimetableMode = useMemo(() => {
-        // 커스텀 내역은 'my' 모드와 'customize' 모드에서 모두 필요하지만,
-        // 사용자 데이터를 가져오는 것은 'my'와 'customize' 모드가 구분되지 않는 경우가 많습니다.
-        // 현재 로직은 'my' 모드에서만 fetchCustomSlots을 호출하지만,
-        // 요청의 의도("나의 타임테이블 뿐 아니라 더많은 타임테이블에서도 보고싶어서")에 따라
-        // API 호출은 모든 커스텀 가능한 페이지에서 필요할 수 있습니다.
-        // 일단 기존 로직대로 'my'/'customize'를 구분하되, fetchCustomSlots을 호출하도록 유지합니다.
-        
         if (location.pathname.includes('/my/')) return 'my';
         if (location.pathname.includes('/customize/')) return 'customize';
         return 'view'; 
     }, [location.pathname]);
     
-    // getPayloadAndCheckSelection 함수는 이전과 동일
     const getPayloadAndCheckSelection = (): { payload: { mt20id: string; invertedSlots: any[] } | null, hasSelections: boolean } => {
         if (!detailData || !detailData.mt20id) return { payload: null, hasSelections: false };
         
@@ -346,20 +332,16 @@ export default function TimetableDetailPage() {
         }
     }, [festivalId]);
     
-    // ⭐️ 2. detailData 로드 후, 커스텀 슬롯 API 호출 (my-detail API는 인증된 사용자의 데이터만 가져옴) ⭐️
+    // ⭐️ 2. detailData 로드 후, 커스텀 슬롯 API 호출 ⭐️
     useEffect(() => {
-        // 'my' 모드뿐 아니라 'customize' 모드에서도 커스텀 내역을 가져와야
-        // 사용자가 이전에 선택한 것을 기반으로 수정을 시작할 수 있습니다.
         if (detailData && detailData.mt20id && (currentMode === 'my' || currentMode === 'customize')) { 
-            // 커스텀 내역을 불러와 activeScheduleKeys에 설정합니다.
             fetchCustomSlots(detailData.mt20id, setActiveScheduleKeys);
         } else if (currentMode === 'view') {
-            // view 모드에서는 커스텀 내역이 필요 없으므로 초기화
             setActiveScheduleKeys(new Set());
         }
     }, [detailData, currentMode]); 
 
-    // saveTimetableData 함수는 이전과 동일 (선택 상태가 없어도 POST 요청을 보내어 삭제 명령을 서버에 전달)
+    // ⭐️⭐️ [Alert 제거] 저장/삭제 성공 메시지를 console.log로 대체 ⭐️⭐️
     const saveTimetableData = async (): Promise<boolean> => { 
         
         const { payload, hasSelections } = getPayloadAndCheckSelection(); 
@@ -382,14 +364,19 @@ export default function TimetableDetailPage() {
         try {
             const response = await api.post(API_ENDPOINT, payload); 
 
-            console.log(`✅ 타임테이블 저장/삭제 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, response.data);
-            alert(hasSelections ? "나의 타임테이블이 성공적으로 서버에 저장되었습니다!" : "나의 타임테이블에서 성공적으로 삭제되었습니다.");
+            // ⚠️ 성공 메시지를 console.log로 대체
+            const successMessage = hasSelections 
+                ? "나의 타임테이블이 성공적으로 서버에 저장되었습니다. 🥳" 
+                : "나의 타임테이블이 성공적으로 서버에서 삭제되었습니다. 🗑️";
+                
+            console.log(`✅ 타임테이블 저장/삭제 성공 (${HTTP_METHOD} ${API_ENDPOINT}):`, successMessage, response.data);
             return true;
 
         } catch (error) {
             const errorMessage = (error as any).response?.data?.message || "알 수 없는 오류가 발생했습니다.";
-            console.error(`❌ 타임테이블 저장/삭제 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, error); 
-            alert(`타임테이블 저장/삭제 중 오류가 발생했습니다: ${errorMessage}`);
+            
+            // ⚠️ 실패 메시지를 console.error로 대체
+            console.error(`❌ 타임테이블 저장/삭제 실패 (${HTTP_METHOD} ${API_ENDPOINT}):`, errorMessage, error); 
             return false;
         }
     };
@@ -401,6 +388,7 @@ export default function TimetableDetailPage() {
              if (saveSuccessful) {
                 navigate(-1);
             } else {
+                // 저장 실패 시 사용자에게 알림 없이 콘솔에만 기록하고 이동 취소
                 console.log("저장 실패로 인해 페이지 이동을 취소합니다.");
             }
         } else {
@@ -463,8 +451,9 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         <div className={timetableStyles.actionButtonWrapper}>
-                            <button className={timetableStyles.actionButton} onClick={() => console.log("저장 기능이 뒤로 가기 버튼으로 이동했습니다.")}>
-                                <img src={download} alt="저장 기능 제거됨"/>
+                            {/* 저장 버튼은 기능이 뒤로 가기에 통합되었고, 모달/alert이 제거되었으므로 콘솔 로그만 남깁니다. */}
+                            <button className={timetableStyles.actionButton} onClick={() => console.log("저장 기능이 뒤로 가기 버튼에 통합되었으며, 모든 알림 창이 제거되었습니다.")}>
+                                <img src={download} alt="저장 기능" />
                             </button>
                             <button className={timetableStyles.actionButton} onClick={handleRefresh}>
                                 <img src={refresh} alt="되돌리기"/>
@@ -485,6 +474,7 @@ export default function TimetableDetailPage() {
                     </div></div>
                     
                 )}
+                
             </main>
         </div>
     );

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,12 +1,105 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import leftarrow from "../../assets/timetable/arrow-left.svg"
+
+// CSS 모듈 (임시)
+import detailStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
+
+// 타입 및 Mock 데이터 import (경로는 실제 프로젝트 구조에 맞게 조정하세요)
+import { FestivalDetailData } from "../../types/timetable"; 
+import { mockFestivalDetail } from "../../data/mockTimetableDetail"; 
 
 
 const TimetableDetailPage = () => {
-  return (
-    <div>
-      <h1>Timetable Detail Page</h1>
-      {/* 여기에 세부 내용 추가 */}
-    </div>
-  );
+    
+    const navigate = useNavigate();
+    // URL 파라미터에서 페스티벌 ID를 문자열로 가져옵니다.
+    const { id: festivalId } = useParams<{ id: string }>(); 
+
+    // 데이터 및 로딩 상태 관리
+    const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const handleGoBack = () => {
+        navigate(-1); 
+    };
+
+    // 데이터 로딩 (API 호출 시뮬레이션)
+    useEffect(() => {
+        // ID가 없거나 유효하지 않으면 로드하지 않습니다.
+        if (!festivalId) {
+            setIsLoading(false);
+            return;
+        }
+
+        async function fetchTimetableDetail() {
+            setIsLoading(true);
+            try {
+                // 500ms 딜레이를 주어 네트워크 로딩을 시뮬레이션
+                await new Promise(resolve => setTimeout(resolve, 500)); 
+                
+                // Mocking: ID가 일치하는지 확인
+                if (parseInt(festivalId) === mockFestivalDetail.festivalId) {
+                    setDetailData(mockFestivalDetail);
+                } else {
+                    setDetailData(null); // 해당 ID의 데이터가 없음
+                }
+
+            } catch (error) {
+                console.error(`[ID:${festivalId}] 상세 타임테이블 로드 오류:`, error);
+                setDetailData(null); 
+            } finally {
+                setIsLoading(false);
+            }
+        }
+
+        fetchTimetableDetail();
+    }, [festivalId]); 
+
+    
+    // --- 로딩/에러 처리 UI ---
+    if (isLoading) {
+        return <div className={detailStyles.pageContainer}>타임테이블 로딩 중...</div>;
+    }
+
+    if (!detailData) {
+        return <div className={detailStyles.pageContainer}>요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
+    }
+
+    // --- 메인 UI 렌더링 ---
+    return (
+        <div className={detailStyles.pageContainer}>
+            
+            {/* 1. 상단 헤더 영역 (뒤로 가기 버튼, 타이틀) */}
+            <header className={detailStyles.header}>
+                <button 
+                    className={detailStyles.backButton}
+                    onClick={handleGoBack}
+                >
+                    <img src={leftarrow} alt="뒤로 가기" />
+                </button>
+                
+                {/* API 응답에서 받은 제목 표시 */}
+                <h1 className={detailStyles.pageTitle}>
+                    {detailData.festivalTitle}
+                </h1>
+                
+                {/* 여기에 커스텀 저장 등의 버튼이 들어갈 수 있습니다. */}
+            </header>
+
+            <main className={detailStyles.mainContent}>
+                
+                {/* 2. 날짜 선택 탭 컴포넌트가 위치할 영역 */}
+                <p>여기에 날짜 탭 컴포넌트를 사용하여 날짜를 선택합니다.</p>
+                
+                {/* 3. 실제 타임테이블 (선택된 날짜의 일정) 컴포넌트가 위치할 영역 */}
+                <p>선택된 날짜: {detailData.days[0].date}</p>
+                <p>총 {detailData.days.length}일 동안 진행되는 페스티벌입니다.</p>
+                
+            </main>
+
+        </div>
+    );
 };
 
 export default TimetableDetailPage;

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -1,86 +1,69 @@
+// src/pages/timetable/TimetableDetailPage.tsx (최종 Hooks 수정 및 3개 Stage 고정)
+
 import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
+// 경로에 맞게 이미지 import 경로는 수정해 주세요.
 import leftarrow from "../../assets/timetable/arrow-left.svg"
-import downarrow from "../../assets/timetable/arrow-down.svg" // downarrow 이미지 import 필요
+import downarrow from "../../assets/timetable/arrow-down.svg"
 import download from "../../assets/timetable/download.svg"
 import refresh from "../../assets/timetable/refresh.svg"
 
 import timetableStyles from "../../css/pages/timetable/timetabledetail.module.css"; 
+import TimetableGrid from "../../components/timetable/TimetableGrid";
 
 
-// 1. 임시 타입 정의
-interface FestivalDetailData {
-  festivalId: number;
-  festivalTitle: string;
-  days: { date: string; stages: { stageName: string; }[] }[]; 
+// =========================================================
+// 1. 타입 정의 및 Mock 데이터 (길이가 길어 생략하며, 이전 코드를 유지하세요)
+// =========================================================
+export interface ScheduleItem { 
+  date: string; stageId: string; stageName: string; stageOrder: number; 
+  artist: string; start: string; end: string; minutes: number; 
+  img: string | null; note: string | null; isCustomized?: boolean; 
 }
+interface DayScheduleData { date: string; schedules: ScheduleItem[]; }
+interface FestivalDetailData { festivalId: number; festivalTitle: string; days: DayScheduleData[]; }
 
 // ⭐️ 날짜 형식 변환 유틸리티 함수 ⭐️
 const formatDayAndDayOfWeek = (dateString: string): string => {
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-
     const date = new Date(dateString);
-
-    if (isNaN(date.getTime())) {
-        console.error("Invalid date format:", dateString);
-        return dateString; 
-    }
-
     const month = date.getMonth() + 1;
     const day = date.getDate();
     const dayOfWeek = weekdays[date.getDay()];
-
     return `${month}.${day}(${dayOfWeek})`;
 };
 
-// ⭐️ 2. 임시 Mock 데이터를 YYYY-MM-DD 형식으로 가정하여 수정 ⭐️
-const MockFestivalDetails: Record<number, FestivalDetailData> = {
-    1: {
-        festivalId: 1, 
-        festivalTitle: "그랜드 민트 페스티벌 2025",
-        days: [
-            { date: "2025-12-20", stages: [{ stageName: "Mint Breeze Stage" }] }, 
-            { date: "2025-12-21", stages: [{ stageName: "Loving Forest Garden" }] }
-        ],
-    },
-    2: {
-        festivalId: 2,
-        festivalTitle: "COUNTDOWN FANTASY 2025-2026",
-        days: [
-            { date: "2025-12-30", stages: [{ stageName: "Fantasy Stage" }] }, 
-            { date: "2025-12-31", stages: [{ stageName: "New Year Stage" }] }
-        ],
-    },
-    3: { 
-        festivalId: 3, 
-        festivalTitle: "COUNTDOWN FANTASY 2025-2026 (추천)", 
-        days: [{ date: "2025-12-20", stages: [{ stageName: "Stage A" }] }] 
-    },
-    4: { 
-        festivalId: 4, 
-        festivalTitle: "DMZ 피스트레인 (추천)", 
-        days: [{ date: "2025-10-18", stages: [{ stageName: "Stage B" }] }] 
-    },
+const MockFestivalDetails: Record<number, FestivalDetailData> = { 
     7: { 
         festivalId: 7, 
-        festivalTitle: "더 많은 페스티벌 1", 
-        days: [{ date: "2025-12-20", stages: [{ stageName: "Main Stage" }] }] 
+        festivalTitle: "더 많은 페스티벌 1 (3 스테이지)", 
+        days: [{ 
+            date: "2025-12-20", schedules: [
+                { date: "2025-12-20", stageId: "A-1", stageName: "LAND STAGE A", stageOrder: 1, artist: "단편선 순간들", start: "15:00:00", end: "15:40:00", minutes: 40, img: null, note: null, isCustomized: true },
+                { date: "2025-12-20", stageId: "A-1", stageName: "LAND STAGE A", stageOrder: 1, artist: "구남과여라이딩스텔라", start: "17:00:00", end: "17:40:00", minutes: 40, img: null, note: null, isCustomized: true },
+                { date: "2025-12-20", stageId: "B-2", stageName: "LAND STAGE B", stageOrder: 2, artist: "사위", start: "15:45:00", end: "16:25:00", minutes: 40, img: null, note: null, isCustomized: true },
+                { date: "2025-12-20", stageId: "B-2", stageName: "LAND STAGE B", stageOrder: 2, artist: "초록불꽃소년단", start: "17:45:00", end: "18:25:00", minutes: 40, img: null, note: null, isCustomized: true },
+                { date: "2025-12-20", stageId: "C-3", stageName: "LAND STAGE C", stageOrder: 3, artist: "THE CHAIRS", start: "16:30:00", end: "17:10:00", minutes: 40, img: null, note: null, isCustomized: true },
+                { date: "2025-12-20", stageId: "C-3", stageName: "LAND STAGE C", stageOrder: 3, artist: "SUMIN", start: "18:30:00", end: "19:10:00", minutes: 40, img: null, note: null },
+                { date: "2025-12-20", stageId: "D-4", stageName: "LAND STAGE D", stageOrder: 4, artist: "New Band", start: "19:30:00", end: "20:30:00", minutes: 60, img: null, note: null },
+            ] 
+        }],
     },
+    // ... (다른 Mock 데이터 유지) ...
 };
-
-// 3. 모드 타입 정의
 type TimetableMode = 'customize' | 'my' | 'view'; 
+
 
 export default function TimetableDetailPage() {
     
+    // ⭐️ 1. 모든 Hooks는 함수 컴포넌트의 최상단에 위치합니다. ⭐️
     const navigate = useNavigate();
     const location = useLocation();
     const { id: festivalId } = useParams<{ id: string }>(); 
 
     const [detailData, setDetailData] = useState<FestivalDetailData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
-    
-    const [currentDayIndex, setCurrentDayIndex] = useState(-1); // 초기값 -1
+    const [currentDayIndex, setCurrentDayIndex] = useState(-1);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
 
@@ -90,29 +73,38 @@ export default function TimetableDetailPage() {
         return 'view'; 
     }, [location.pathname]);
 
-    const handleGoBack = () => {
-        navigate(-1); 
-    };
     
-    // ⭐️ 다운로드 버튼 핸들러 ⭐️
-    const handleDownload = () => {
-        console.log("Download button clicked!");
-        // 여기에 타임테이블 이미지 저장 로직 구현
-    };
+    // ⭐️ 2. 데이터 추출 및 필터링 useMemo도 Early Return 이전에 선언 ⭐️
+    const allSchedules = useMemo(() => {
+        // detailData나 days가 없을 경우 안전하게 빈 배열 반환
+        if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) {
+            return [];
+        }
+        return detailData.days[currentDayIndex].schedules;
+    }, [detailData, currentDayIndex]);
     
-    // ⭐️ 되돌리기/리프레시 버튼 핸들러 ⭐️
-    const handleRefresh = () => {
-        console.log("Refresh/Reset button clicked!");
-        // 여기에 커스텀 타임테이블 초기화 또는 되돌리기 로직 구현
-    };
-    
-    // ⭐️ 날짜 선택 핸들러 ⭐️
-    const handleDaySelect = (index: number) => {
-        setCurrentDayIndex(index);
-        setIsDropdownOpen(false); // 선택 후 드롭다운 닫기
-    };
+    // ⭐️ Stage 3개 고정 필터링 로직 ⭐️
+    const schedulesByStage = useMemo(() => {
+        const stage1Schedules = allSchedules.filter(s => s.stageOrder === 1);
+        const stage2Schedules = allSchedules.filter(s => s.stageOrder === 2);
+        const stage3Schedules = allSchedules.filter(s => s.stageOrder === 3);
 
-    // 데이터 로딩 (API 호출 시뮬레이션)
+        const stageNames = {
+            1: stage1Schedules[0]?.stageName || "Stage 1",
+            2: stage2Schedules[0]?.stageName || "Stage 2",
+            3: stage3Schedules[0]?.stageName || "Stage 3",
+        };
+        
+        return {
+            stage1: stage1Schedules,
+            stage2: stage2Schedules,
+            stage3: stage3Schedules,
+            stageNames: stageNames,
+        };
+    }, [allSchedules]);
+
+
+    // --- useEffect, 핸들러 (이전 코드 유지) ---
     useEffect(() => {
         if (!festivalId) { 
             setIsLoading(false);
@@ -126,15 +118,14 @@ export default function TimetableDetailPage() {
                 
                 let dataToLoad: FestivalDetailData | null = null;
                 const idNum = parseInt(festivalId!); 
-                const baseData = MockFestivalDetails[idNum];
-
+                const baseData = MockFestivalDetails[idNum] || MockFestivalDetails[7]; 
+                
                 if (baseData) {
                     dataToLoad = baseData;
-                    // 데이터 로드 완료 후, 첫 번째 날짜(인덱스 0)를 기본 선택하도록 설정
-                    setCurrentDayIndex(0); 
-                    setIsDropdownOpen(false); 
+                    if (baseData.days.length > 0) {
+                        setCurrentDayIndex(0); 
+                    }
                 }
-                
                 setDetailData(dataToLoad); 
 
             } catch (error) {
@@ -144,40 +135,36 @@ export default function TimetableDetailPage() {
                 setIsLoading(false);
             }
         }
-
         fetchTimetableDetail();
     }, [festivalId, currentMode]); 
 
-    
-    // --- 로딩/에러 처리 UI ---
+    const handleGoBack = () => { navigate(-1); };
+    const handleDownload = () => { console.log("Download button clicked!"); };
+    const handleRefresh = () => { console.log("Refresh/Reset button clicked!"); };
+    const handleDaySelect = (index: number) => {
+        setCurrentDayIndex(index);
+        setIsDropdownOpen(false);
+    };
+
+
+    // --- Early Return ---
     if (isLoading) {
         return <div className={timetableStyles.pageContainer}>타임테이블 로딩 중...</div>;
     }
 
-    if (!detailData) {
-        return <div className={timetableStyles.pageContainer}>요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: {festivalId})</div>;
+    if (!detailData || currentDayIndex === -1 || !detailData.days[currentDayIndex]) {
+        return <div className={timetableStyles.pageContainer}>
+            {detailData ? "날짜를 선택해 주세요." : `요청하신 페스티벌 정보를 찾을 수 없습니다. (ID: ${festivalId})`}
+        </div>;
     }
-
-    // 현재 선택된 날짜 데이터 준비
+    
     const selectedDayData = detailData.days[currentDayIndex];
     
-    // 현재 선택된 날짜를 포맷팅. (currentDayIndex가 -1이 아닐 경우만 사용)
-    const selectedDateFormatted = currentDayIndex !== -1 
-        ? formatDayAndDayOfWeek(selectedDayData.date)
-        : "날짜 선택";
-
-    // ⭐️ 토글 버튼에 표시될 최종 텍스트 결정 ⭐️
-    const toggleButtonText = isDropdownOpen
-        ? "날짜 선택" // 드롭다운이 열리면 '날짜 선택' 표시
-        : selectedDateFormatted; // 닫혀 있으면 선택된 날짜 표시
-
-    // ⭐️ 토글 버튼 클래스 (open/close 상태에 따라 테두리 색상 변경 및 화살표 회전) ⭐️
+    const selectedDateFormatted = formatDayAndDayOfWeek(selectedDayData.date);
+    const toggleButtonText = isDropdownOpen ? "날짜 선택" : selectedDateFormatted;
     const toggleClass = `${timetableStyles.dayDropdownToggle} ${isDropdownOpen ? timetableStyles.open : ''}`;
-    
-    // ⭐️ 텍스트 클래스 (선택된 날짜가 있을 때만 보라색 fontSet 적용) ⭐️
-    const textClass = currentDayIndex !== -1 && !isDropdownOpen
-        ? timetableStyles.fontSet
-        : timetableStyles.placeholderText;
+    const textClass = currentDayIndex !== -1 && !isDropdownOpen ? timetableStyles.fontSet : timetableStyles.placeholderText;
+
 
     // --- 메인 UI 렌더링 ---
     return (
@@ -199,19 +186,12 @@ export default function TimetableDetailPage() {
 
             <main className={timetableStyles.mainContent}>
                 
-               {/* ⭐️ 1. 컨트롤 바 (드롭다운 + 다운로드/리프레시 버튼) ⭐️ */}
+               {/* 1. 컨트롤 바 (드롭다운 + 다운로드/리프레시 버튼) */}
                 {detailData.days.length > 0 && (
-                    <div className={timetableStyles.timetableControlBar}>
-                        
-                        {/* 1-1. 드롭다운 래퍼: absolute list의 기준점 */}
+                     <div className={timetableStyles.timetableControlBar}>
                         <div className={timetableStyles.dropdownWrapper}>
-                            <button
-                                className={toggleClass}
-                                onClick={() => setIsDropdownOpen(prev => !prev)}
-                            >
-                                <span className={textClass}>
-                                    {toggleButtonText}
-                                </span>
+                            <button className={toggleClass} onClick={() => setIsDropdownOpen(prev => !prev)}>
+                                <span className={textClass}>{toggleButtonText}</span>
                                 <img 
                                     src={downarrow} 
                                     alt="드롭다운 화살표"
@@ -219,21 +199,16 @@ export default function TimetableDetailPage() {
                                 />
                             </button>
 
-                            {/* 2. 날짜 목록 (isDropdownOpen이 true일 때만 표시) */}
                             {isDropdownOpen && (
                                 <ul className={timetableStyles.dayDropdownList}>
                                     {detailData.days.map((day, index) => (
-                                        <li 
-                                            key={index}
-                                            className={timetableStyles.dayDropdownItem}
-                                        >
+                                        <li key={index} className={timetableStyles.dayDropdownItem}>
                                             <button
                                                 className={`${timetableStyles.dayDropdownOption} ${
                                                     index === currentDayIndex ? timetableStyles.active : ''
                                                 }`}
                                                 onClick={() => handleDaySelect(index)}
                                             >
-                                                {/* ⭐️ 수정: 텍스트를 <span>으로 감싸서 별도의 박스 스타일을 적용할 수 있도록 함 ⭐️ */}
                                                 <span 
                                                     className={`${timetableStyles.selectedDateTextWrapper} ${
                                                         index === currentDayIndex ? timetableStyles.dateTextActive : ''
@@ -248,7 +223,6 @@ export default function TimetableDetailPage() {
                             )}
                         </div>
                         
-                        {/* 1-2. 액션 버튼 래퍼 */}
                         <div className={timetableStyles.actionButtonWrapper}>
                             <button className={timetableStyles.actionButton} onClick={handleDownload}>
                                 <img src={download} alt="다운로드" />
@@ -261,21 +235,21 @@ export default function TimetableDetailPage() {
                     </div>
                 )}
                 
-                {/* ⭐️ 2. 선택된 날짜의 스테이지/일정 영역 (날짜가 선택되었을 때만 표시) ⭐️ */}
+                {/* ⭐️ 2. 타임테이블 영역 ⭐️ */}
                 {currentDayIndex !== -1 && (
                     <div className={timetableStyles.scheduleArea}>
                         
                         <h3>{formatDayAndDayOfWeek(selectedDayData.date)} 일정</h3>
                         
-                        {/* TODO: 여기에 스테이지 필터와 실제 타임테이블 목록이 들어갑니다. */}
-                        <div style={{ marginTop: '10px', padding: '10px', border: '1px solid #ccc' }}>
-                            <p>선택된 날짜의 스테이지 수: {selectedDayData.stages.length}</p>
-                            <ul>
-                                {selectedDayData.stages.map((stage, index) => (
-                                    <li key={index}>{stage.stageName}</li>
-                                ))}
-                            </ul>
-                        </div>
+                        {/* Stage 3개 고정 Props 전달 */}
+                        <TimetableGrid 
+                            stage1Schedules={schedulesByStage.stage1}
+                            stage2Schedules={schedulesByStage.stage2}
+                            stage3Schedules={schedulesByStage.stage3}
+                            stageNames={schedulesByStage.stageNames}
+                            allSchedules={allSchedules}
+                            mode={currentMode}
+                        />
 
                     </div>
                 )}

--- a/src/pages/timetable/TimetableDetailPage.tsx
+++ b/src/pages/timetable/TimetableDetailPage.tsx
@@ -239,7 +239,7 @@ export default function TimetableDetailPage() {
                 {currentDayIndex !== -1 && (
                     <div className={timetableStyles.scheduleArea}>
                         
-                        <h3>{formatDayAndDayOfWeek(selectedDayData.date)} 일정</h3>
+                        
                         
                         {/* Stage 3개 고정 Props 전달 */}
                         <TimetableGrid 

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableMainPage.tsx (전체 코드 - likeCount 제거 후)
+// src/pages/timetable/TimetableMainPage.tsx (날짜 형식 수정 최종 버전)
 
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -14,27 +14,27 @@ export interface KopisFestivalItem {
   id: number;
   mt20id: string; 
   prfnm: string; 
-  prfpdfrom: string; 
-  prfpdto: string; 
+  prfpdfrom: string; // 시작일 (YYYY-MM-DD)
+  prfpdto: string;   // 종료일 (YYYY-MM-DD)
   fcltynm: string; 
   poster: string; 
   
   performanceId?: number; 
   title?: string; 
   posterUrl?: string; 
-
-  isLiked?: boolean; 
-  likeCount?: number; // API 응답에는 포함될 수 있지만, UI 로직에서는 사용하지 않음
+  
+  newstate?: boolean; 
+  isLiked?: boolean; // 이전 필드는 옵셔널로 유지
+  likeCount?: number; 
 }
 
-// ⭐️ [UI 타입] 최종 FestivalItem 타입 (likeCount 제거) ⭐️
+// ⭐️ [UI 타입] 최종 FestivalItem 타입 ⭐️
 export interface FestivalItem {
   id: number;
   title: string;
-  // likeCount: number; // UI에서 사용하지 않으므로 제거
   isLiked: boolean; 
   location: string;
-  date: string; 
+  date: string; // YYYY.MM.DD - MM.DD 형식으로 저장됨
   thumbnailUrl: string;
 }
 
@@ -88,9 +88,10 @@ const TimetableMainPage = () => {
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.performanceId,
           title: item.title,
-          isLiked: true, // 이 목록은 무조건 좋아요 상태임
+          isLiked: true, 
           location: item.fcltynm,
-          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
+          // ⚠️ 날짜 형식 수정 적용
+          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
           thumbnailUrl: item.posterUrl,
       }));
 
@@ -108,7 +109,7 @@ const TimetableMainPage = () => {
   }, []); 
 
   
-  const fetchMyTimetables = async () => {
+  const fetchMyTimetables = useCallback(async () => {
     setIsMyListLoading(true);
     setMyListError(null);
     
@@ -121,9 +122,10 @@ const TimetableMainPage = () => {
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.id,
           title: item.prfnm,
-          isLiked: item.isLiked || false, 
+          isLiked: item.isLiked ?? item.newstate ?? false, 
           location: item.fcltynm, 
-          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
+          // ⚠️ 날짜 형식 수정 적용
+          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
           thumbnailUrl: item.poster, 
       }));
 
@@ -135,52 +137,81 @@ const TimetableMainPage = () => {
     } finally {
       setIsMyListLoading(false);
     }
-  };
+  }, []);
 
 
-  // 더 많은 페스티벌 목록 조회
+  // ⭐️ 더 많은 페스티벌 목록 조회 (좋아요 상태 영구 유지를 위해 사용자 좋아요 정보 병합) ⭐️
   const fetchMoreFestivals = useCallback(async (sortKey: string) => {
     setIsLoading(true);
     setError(null);
     
+    // 1. 좋아요 상태 확인을 위해 사용자의 관심 목록 ID를 가져옵니다.
+    let userLikedIds: Set<number> = new Set();
     try {
-      // ⭐️ 핵심 GET 요청: 이 응답에서 isLiked가 true로 와야 함 ⭐️
-      const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
-      const apiData: KopisFestivalItem[] = response.data; 
-      
-      const transformedData: FestivalItem[] = apiData.map(item => ({
-          id: item.id,
-          title: item.prfnm, 
-          isLiked: item.isLiked || false, 
-          location: item.fcltynm, 
-          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
-          thumbnailUrl: item.poster, 
-      }));
-
-      setMorefestival(transformedData);
-      
+        const likesResponse = await api.get('/likes/my/festivals');
+        const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
+        userLikedIds = new Set(likedApiData.map(item => item.performanceId || item.id)); 
     } catch (err) {
-      console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
-      setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
-      setMorefestival([]);
+        console.warn("⚠️ 관심 목록 로드 실패: 메인 목록은 기본 isLiked=false로 진행됩니다.");
+    }
+
+    try {
+        // 2. 메인 페스티벌 목록을 가져옵니다.
+        const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
+        const apiData: KopisFestivalItem[] = response.data.data || response.data; 
+        
+        // 3. 메인 목록에 사용자 좋아요 상태를 병합(Merge)합니다.
+        const transformedData: FestivalItem[] = apiData.map(item => ({
+            id: item.id,
+            title: item.prfnm, 
+            isLiked: userLikedIds.has(item.id), 
+            location: item.fcltynm, 
+            // ⚠️ 날짜 형식 수정 적용
+            date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
+            thumbnailUrl: item.poster, 
+        }));
+
+        setMorefestival(transformedData);
+        
+    } catch (err) {
+        console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
+        setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
+        setMorefestival([]);
     } finally {
-      setIsLoading(false);
+        setIsLoading(false);
     }
   }, []); 
 
 
-  // 좋아요 상태 변경 시 목록 전체 새로고침 콜백
-  const handleLikeChangeSuccess = useCallback(() => {
-    // 좋아요가 성공하면 관련 목록을 모두 새로고침
+  // 좋아요 상태 변경 성공 콜백: 모든 목록에 로컬 업데이트를 적용합니다.
+  const handleLikeChangeSuccess = useCallback((festivalId: number, newIsLikedState: boolean) => {
+    
+    // 1. '더 많은 페스티벌' 목록 (morefestival) 로컬 업데이트 (즉시 반영)
+    setMorefestival(prevList => {
+        const newList = prevList.map(item => 
+            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
+        );
+        return newList;
+    });
+    
+    // 2. '나의 타임테이블' 목록 (myTimetables) 로컬 업데이트 (즉시 반영)
+    setMyTimetables(prevList => {
+        const newList = prevList.map(item => 
+            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
+        );
+        return newList;
+    });
+    
+    // 3. '나의 관심 페스티벌' 목록을 API로 새로고침 (이 목록은 항목 자체가 추가/제거되므로 API 호출이 필요)
     fetchMyFavorites(); 
-    fetchMoreFestivals(currentSort); 
-  }, [fetchMyFavorites, fetchMoreFestivals, currentSort]);
+    
+  }, [fetchMyFavorites]);
 
 
   useEffect(() => {
     fetchMyTimetables();
     fetchMyFavorites(); 
-  }, [fetchMyFavorites]); 
+  }, [fetchMyFavorites, fetchMyTimetables]); 
   
   useEffect(() => {
     fetchMoreFestivals(currentSort);
@@ -213,7 +244,7 @@ const TimetableMainPage = () => {
                   key={item.id}
                   itemData={item}
                   onClick={() => handleMyTimetableClick(item.id)}
-                  onLikeChangeSuccess={handleLikeChangeSuccess} 
+                  onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
                 />
               ))}
             </ul>
@@ -286,7 +317,7 @@ const TimetableMainPage = () => {
                   key={item.id}
                   itemData={item}
                   onClick={() => handleCustomizeClick(item.id)}
-                  onLikeChangeSuccess={handleLikeChangeSuccess} 
+                  onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
                 />
               ))}
             </ul>

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -7,12 +7,26 @@ import FestivalListItem from "../../components/timetable/FestivalListItem";
 import SectionHeader from "../../components/SectionHeader";
 import RecommendCard from "../../components/timetable/RecommendCard";
 import Alarm from "../../components/Alarm";
+import api from "../../api/api"; // ⭐️ 사용자가 import 한 api 객체 ⭐️
+
+// ⭐️ API 응답 타입 정의 (더 많은 페스티벌 API의 응답 구조) ⭐️
+// 실제 API 응답 구조를 기반으로 필드명을 사용합니다.
+interface KopisFestivalItem {
+  id: number; // FestivalItem의 id와 매핑
+  mt20id: string; 
+  prfnm: string; // FestivalItem의 title과 매핑 (공연명)
+  prfpdfrom: string; // 공연 시작일
+  prfpdto: string; // 공연 종료일
+  fcltynm: string; // FestivalItem의 location과 매핑 (시설명)
+  poster: string; // FestivalItem의 thumbnailUrl과 매핑 (포스터 URL)
+  // ... 기타 필드 (생략)
+}
 
 // ⭐️ 수정: 인터페이스를 export 합니다. ⭐️
 export interface FestivalItem {
   id: number;
   title: string;
-  likes: number;
+  likes: number; // API에 없는 경우 0으로 임시 설정 필요
   location: string;
   date: string;
   thumbnailUrl: string;
@@ -33,12 +47,19 @@ const sortOptions = [
 
 const TimetableMainPage = () => {
   const navigate = useNavigate();
+  
   // Mock 데이터
   const [timetableList, setTimetableList] = useState<FestivalItem[]>([]);
   const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]);
+  
+  // ⭐️ API 데이터 상태 ⭐️
   const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
-
   const [currentSort, setCurrentSort] = useState(sortOptions[0].key); 
+  
+  // ⭐️ API 호출 상태 ⭐️
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
 
   // 1. 커스텀 '생성' 경로 이동 함수
   const handleCustomizeClick = (festivalId: number) => { 
@@ -50,16 +71,50 @@ const TimetableMainPage = () => {
     navigate(`/main/timetable/my/${festivalId}`);
   };
 
+  // ⭐️ API 호출 함수: 더 많은 페스티벌 목록 조회 ⭐️
+  const fetchMoreFestivals = async (sortKey: string) => {
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      // ⭐️ api 객체를 사용하여 GET 요청을 보냅니다. ⭐️
+      // API 주소: /kopis/performances/festivals (v1은 제외)
+      const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
+      
+      const apiData: KopisFestivalItem[] = response.data; 
+      
+      // ⭐️ API 응답을 FestivalItem 타입에 맞게 변환 (매핑) ⭐️
+      const transformedData: FestivalItem[] = apiData.map(item => ({
+          id: item.id,
+          title: item.prfnm, 
+          likes: 0, // API에 '좋아요' 데이터가 없으므로 0으로 임시 처리
+          location: item.fcltynm, 
+          date: `${item.prfpdfrom} - ${item.prfpdto}`, 
+          thumbnailUrl: item.poster, 
+      }));
+
+      setMorefestival(transformedData);
+      
+    } catch (err) {
+      console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
+      // 에러 객체에 따라 메시지를 다르게 처리할 수 있습니다.
+      setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
+      setMorefestival([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
 
   useEffect(() => {
-    // Mock Data 초기화
+    // 1. 나의 타임테이블 (Mock Data)
     const mockData1: FestivalItem[] = [
        { id: 1, title: "그랜드 민트 페스티벌 2025", likes: 12, location: "일산 킨텍스", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/img1.png" },
       { id: 2, title: "COUNTDOWN FANTASY 2025-2026", likes: 10, location: "일산 킨텍스", date: "2025.12.30 - 2025.12.31", thumbnailUrl: "/path/to/img2.png" },
-    
     ];
     setTimetableList(mockData1);
 
+    // 2. 추천 페스티벌 (Mock Data)
     const mockData2: RecommendItem[] = [
        { id: 3, title: "COUNTDOWN FANTASY 2025-2026", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster1.png" },
       { id: 4, title: "DMZ 피스트레인 뮤직 페스티벌 2025", date: "2025.10.18 - 2025.10.19", thumbnailUrl: "/path/to/poster2.png" },
@@ -68,17 +123,14 @@ const TimetableMainPage = () => {
      ];
     setRecommendedFestivals(mockData2);
     
-    const mockData3: FestivalItem[] = [
-        { id: 7, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 8, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 9, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 10, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 11, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 12, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-        
-    ];
-    setMorefestival(mockData3);
+    // ⭐️ 3. 더 많은 페스티벌 Mock Data 제거 (API 호출로 대체) ⭐️
+    // setMorefestival(mockData3);
   }, []);
+  
+  // ⭐️ currentSort 상태가 변경되거나 컴포넌트 마운트 시 API 호출 ⭐️
+  useEffect(() => {
+    fetchMoreFestivals(currentSort);
+  }, [currentSort]); // currentSort이 변경될 때마다 실행
 
   const listData = timetableList;
   const recommendData = recommendedFestivals;
@@ -139,6 +191,7 @@ const TimetableMainPage = () => {
                 className={`${timetablestyles.sortButton} ${
                   currentSort === option.key ? timetablestyles.active : ""
                 }`}
+                // ⭐️ 정렬 버튼 클릭 시 currentSort 상태 업데이트 (-> useEffect 실행) ⭐️
                 onClick={() => setCurrentSort(option.key)}
               >
                 {option.label}
@@ -146,16 +199,27 @@ const TimetableMainPage = () => {
             ))}
           </div>
           
+          {/* ⭐️ 로딩 및 에러 상태 표시 ⭐️ */}
+          {isLoading && <p className={timetablestyles.loadingText}>페스티벌 목록을 불러오는 중...</p>}
+          {error && <p className={timetablestyles.errorText}>{error}</p>}
+          
+          {/* ⭐️ 데이터가 로드되었을 때만 목록 표시 ⭐️ */}
+          {!isLoading && !error && displayFestivalData.length > 0 && (
+            <ul className={timetablestyles.timetableList}>
+              {displayFestivalData.map((item) => (
+                <FestivalListItem
+                  key={item.id}
+                  itemData={item}
+                  onClick={() => handleCustomizeClick(item.id)}
+                />
+              ))}
+            </ul>
+          )}
+          
+          {!isLoading && !error && displayFestivalData.length === 0 && (
+            <p className={timetablestyles.noDataText}>해당 조건에 맞는 페스티벌이 없습니다.</p>
+          )}
 
-          <ul className={timetablestyles.timetableList}>
-            {displayFestivalData.map((item) => (
-              <FestivalListItem
-                key={item.id}
-                itemData={item}
-                onClick={() => handleCustomizeClick(item.id)}
-              />
-            ))}
-          </ul>
         </section>
       </div>
     </>

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,3 +1,5 @@
+// src/pages/timetable/TimetableMainPage.tsx
+
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import timetablestyles from "../../css/pages/timetable/timetablemain.module.css";
@@ -7,8 +9,7 @@ import RecommendCard from "../../components/timetable/RecommendCard";
 import Alarm from "../../components/Alarm";
 import api from "../../api/api"; 
 
-// ⭐️ API 응답 타입 정의 (KopisFestivalItem: JSON 요청 형식과 매핑) ⭐️
-// 실제 API 응답 구조를 기반으로 필드명을 사용합니다.
+// ⭐️ API 응답 타입 정의 (KopisFestivalItem: /kopis 및 /festivals/custom 모두 사용) ⭐️
 export interface KopisFestivalItem {
   id: number; // FestivalItem의 id와 매핑
   mt20id: string; // Kopis 공연 ID
@@ -23,7 +24,6 @@ export interface KopisFestivalItem {
   prfstate: string; // 공연 상태
   dtguidance: string; // 시간 안내
   tkstdate: string; // 티켓 오픈일
-  // ... 기타 필드 (요청하신 JSON 형식에 포함된 필드를 모두 추가했습니다.)
   tksttime: { hour: number; minute: number; second: number; nano: number; };
   typeofcon: number;
   newstate: boolean;
@@ -32,12 +32,12 @@ export interface KopisFestivalItem {
   relates: { relatenm: string; relateurl: string; }[];
   days: { date: string; open: { hour: number; minute: number; second: number; nano: number; }; close: { hour: number; minute: number; second: number; nano: number; }; }[];
   slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: { hour: number; minute: number; second: number; nano: number; }; end: { hour: number; minute: number; second: number; nano: number; }; minutes: number; img: string; note: string; }[];
-  fesLinks: { relatenm: string; relateurl: string; }[];
+  fesLinks: { relatenm: string; url: string; }[];
   artistPics: { date: string; relatenm: string; url: string; }[];
 }
 
 
-// ⭐️ 수정: 인터페이스를 export 합니다. (UI 컴포넌트에 필요한 필드) ⭐️
+// ⭐️ UI 컴포넌트에 필요한 최종 FestivalItem 타입 (기존 유지) ⭐️
 export interface FestivalItem {
   id: number;
   title: string;
@@ -63,8 +63,8 @@ const sortOptions = [
 const TimetableMainPage = () => {
   const navigate = useNavigate();
   
-  // Mock 데이터
-  const [timetableList, setTimetableList] = useState<FestivalItem[]>([]);
+  // ⭐️ [수정] 나의 타임테이블 목록 상태를 API 데이터로 변경 ⭐️
+  const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
   const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]);
   
   // ⭐️ API 데이터 상태 ⭐️
@@ -73,7 +73,10 @@ const TimetableMainPage = () => {
   
   // ⭐️ API 호출 상태 ⭐️
   const [isLoading, setIsLoading] = useState(false);
+  // ⭐️ [추가] 나의 타임테이블 전용 로딩/에러 상태 ⭐️
+  const [isMyListLoading, setIsMyListLoading] = useState(true); 
   const [error, setError] = useState<string | null>(null);
+  const [myListError, setMyListError] = useState<string | null>(null); 
 
 
   // 1. 커스텀 '생성' 경로 이동 함수
@@ -85,8 +88,48 @@ const TimetableMainPage = () => {
   const handleMyTimetableClick = (festivalId: number) => { 
     navigate(`/main/timetable/my/${festivalId}`);
   };
+  
+  // ⭐️ ⭐️ [새로운 API 호출] 나의 타임테이블 목록 조회 함수 ⭐️ ⭐️
+  // API 주소: /festivals/custom
+  const fetchMyTimetables = async () => {
+    setIsMyListLoading(true);
+    setMyListError(null);
+    
+    const API_ENDPOINT = '/festivals/custom'; 
+    
+    try {
+      // ⭐️ GET /festivals/custom 호출 (인증 헤더 필요) ⭐️
+      const response = await api.get(API_ENDPOINT); 
+      
+      // API 응답 데이터가 KopisFestivalItem[] 배열 형태라고 가정합니다.
+      const apiData: KopisFestivalItem[] = response.data.data || response.data; 
+      
+      // ⭐️ API 응답을 FestivalItem 타입에 맞게 변환 (매핑 로직) ⭐️
+      const transformedData: FestivalItem[] = apiData.map(item => ({
+          id: item.id, // FestivalListItem의 key와 id로 사용
+          title: item.prfnm, // 공연명 (title)
+          likes: 0, // 좋아요 데이터가 없다면 임시 값 사용
+          location: item.fcltynm, // 시설명 (location)
+          // prfpdfrom(시작일)과 prfpdto(종료일)을 조합하여 date 형식으로 만듦
+          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
+          thumbnailUrl: item.poster, // 포스터 URL (thumbnailUrl)
+      }));
 
-  // ⭐️ API 호출 함수: 더 많은 페스티벌 목록 조회 ⭐️
+      setMyTimetables(transformedData);
+      console.log(`✅ [GET ${API_ENDPOINT}] 나의 타임테이블 목록 응답:`, response.data);
+      
+    } catch (err) {
+      console.error(`❌ 나의 타임테이블 목록 (${API_ENDPOINT}) 로드 중 오류 발생:`, err);
+      // 로그인 문제 등 4xx 에러 처리를 위해 에러 메시지 업데이트
+      setMyListError("나의 타임테이블을 불러오는 데 실패했습니다. (로그인 상태 확인)");
+      setMyTimetables([]);
+    } finally {
+      setIsMyListLoading(false);
+    }
+  };
+
+
+  // ⭐️ API 호출 함수: 더 많은 페스티벌 목록 조회 (기존 유지) ⭐️
   const fetchMoreFestivals = async (sortKey: string) => {
     setIsLoading(true);
     setError(null);
@@ -123,14 +166,10 @@ const TimetableMainPage = () => {
 
 
   useEffect(() => {
-    // 1. 나의 타임테이블 (Mock Data)
-    const mockData1: FestivalItem[] = [
-       { id: 1, title: "그랜드 민트 페스티벌 2025", likes: 12, location: "일산 킨텍스", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/img1.png" },
-      { id: 2, title: "COUNTDOWN FANTASY 2025-2026", likes: 10, location: "일산 킨텍스", date: "2025.12.30 - 2025.12.31", thumbnailUrl: "/path/to/img2.png" },
-    ];
-    setTimetableList(mockData1);
-
-    // 2. 추천 페스티벌 (Mock Data)
+    // ⭐️ ⭐️ [수정] 1. 나의 타임테이블 API 호출로 대체 ⭐️ ⭐️
+    fetchMyTimetables();
+    
+    // 2. 추천 페스티벌 (Mock Data 유지)
     const mockData2: RecommendItem[] = [
        { id: 3, title: "COUNTDOWN FANTASY 2025-2026", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster1.png" },
       { id: 4, title: "DMZ 피스트레인 뮤직 페스티벌 2025", date: "2025.10.18 - 2025.10.19", thumbnailUrl: "/path/to/poster2.png" },
@@ -139,15 +178,15 @@ const TimetableMainPage = () => {
      ];
     setRecommendedFestivals(mockData2);
     
-    // 3. 더 많은 페스티벌 Mock Data 제거 (API 호출로 대체)
   }, []);
   
-  // ⭐️ currentSort 상태가 변경되거나 컴포넌트 마운트 시 API 호출 ⭐️
+  // ⭐️ currentSort 상태가 변경되거나 컴포넌트 마운트 시 API 호출 (기존 유지) ⭐️
   useEffect(() => {
     fetchMoreFestivals(currentSort);
-  }, [currentSort]); // currentSort이 변경될 때마다 실행
+  }, [currentSort]); 
 
-  const listData = timetableList;
+  // ⭐️ [수정] myTimetables 상태 사용 ⭐️
+  const myTimetableDisplayData = myTimetables; 
   const recommendData = recommendedFestivals;
   const displayFestivalData = morefestival; 
 
@@ -163,17 +202,29 @@ const TimetableMainPage = () => {
             boldParts={[1]}
           />
 
-          <ul className={timetablestyles.timetableList}>
-            {listData.map((item) => (
-              <FestivalListItem
-                key={item.id}
-                itemData={item}
-                onClick={() => handleMyTimetableClick(item.id)}
-              />
-            ))}
-          </ul>
+          {/* ⭐️ [수정] 나의 타임테이블 로딩/에러/데이터 표시 로직 ⭐️ */}
+          {isMyListLoading && <p className={timetablestyles.loadingText}>나의 타임테이블을 불러오는 중...</p>}
+          {myListError && <p className={timetablestyles.errorText}>{myListError}</p>}
+
+          {!isMyListLoading && !myListError && myTimetableDisplayData.length > 0 && (
+            <ul className={timetablestyles.timetableList}>
+              {myTimetableDisplayData.map((item) => (
+                <FestivalListItem
+                  key={item.id}
+                  itemData={item}
+                  onClick={() => handleMyTimetableClick(item.id)}
+                />
+              ))}
+            </ul>
+          )}
+          
+          {!isMyListLoading && !myListError && myTimetableDisplayData.length === 0 && (
+            <p className={timetablestyles.noDataText}>나만의 타임테이블을 만들어 보세요!</p>
+          )}
+
         </section>
 
+        {/* --- 추천 페스티벌 섹션은 변경 없음 --- */}
         <section className={timetablestyles.check}>
           <SectionHeader
             subtitle="나의 관심 페스티벌의"
@@ -191,7 +242,9 @@ const TimetableMainPage = () => {
             ))}
           </div>
         </section>
+        {/* --- */}
 
+        {/* --- 더 많은 페스티벌 섹션은 변경 없음 --- */}
         <section className={timetablestyles.moretimetableSection}>
           <SectionHeader
             subtitle="더 많은 페스티벌의"
@@ -206,7 +259,6 @@ const TimetableMainPage = () => {
                 className={`${timetablestyles.sortButton} ${
                   currentSort === option.key ? timetablestyles.active : ""
                 }`}
-                // ⭐️ 정렬 버튼 클릭 시 currentSort 상태 업데이트 (-> useEffect 실행) ⭐️
                 onClick={() => setCurrentSort(option.key)}
               >
                 {option.label}

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -25,6 +25,7 @@ export interface KopisFestivalItem {
 
 export interface FestivalItem {
   id: number;
+  mt20id: string;
   title: string;
   isLiked: boolean;
   location: string;
@@ -39,15 +40,15 @@ const TimetableMainPage = () => {
   const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
   const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]);
   const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+
+  const [isMoreLoading, setIsMoreLoading] = useState(false);
   const [isMyListLoading, setIsMyListLoading] = useState(true);
-  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [isFavoritesLoading, setIsFavoritesLoading] = useState(true);
+
+  const [moreError, setMoreError] = useState<string | null>(null);
   const [myListError, setMyListError] = useState<string | null>(null);
   const [favoritesError, setFavoritesError] = useState<string | null>(null);
   
-
-
   const handleCustomizeClick = (festivalId: number) => {
     navigate(`/main/timetable/customize/${festivalId}`);
   };
@@ -56,16 +57,23 @@ const TimetableMainPage = () => {
     navigate(`/main/timetable/my/${festivalId}`);
   };
 
-
-  const fetchMyFavorites = useCallback(async () => {
+  const handleConcertDetailClick = (mt20id: string) => {
+    navigate(`/main/concert/${mt20id}`); 
+  };
+  
+  const fetchUserLikedIdsAndFavorites = useCallback(async () => {
     setIsFavoritesLoading(true);
     setFavoritesError(null);
     const API_ENDPOINT = "/likes/my/festivals";
     try {
       const response = await api.get(API_ENDPOINT);
       const apiData: any[] = response.data.data || response.data;
-      const transformedData: FestivalItem[] = apiData.map((item) => ({
-        id: item.performanceId,
+      
+      const likedIds = new Set(apiData.map((item) => item.performanceId || item.id));
+      
+      const transformedData: RecommendItem[] = apiData.map((item) => ({
+        id: item.performanceId || item.id,
+        mt20id: item.mt20id,
         title: item.title,
         isLiked: true,
         location: item.fcltynm,
@@ -74,30 +82,22 @@ const TimetableMainPage = () => {
           .replace(/-/g, ".")}`,
         thumbnailUrl: item.posterUrl,
       }));
-
-    
-      setRecommendedFestivals(transformedData as RecommendItem[]);
+      setRecommendedFestivals(transformedData);
+      
+      return likedIds;
     } catch (err) {
       setFavoritesError("관심 목록을 불러오는 데 실패했습니다.");
-
       setRecommendedFestivals([]);
+      return new Set<number>();
     } finally {
       setIsFavoritesLoading(false);
     }
   }, []);
 
-  const fetchMyTimetables = useCallback(async () => {
+
+  const fetchMyTimetables = useCallback(async (likedIds: Set<number>) => {
     setIsMyListLoading(true);
     setMyListError(null);
-
-    let userLikedIds: Set<number> = new Set();
-    try {
-      const likesResponse = await api.get("/likes/my/festivals");
-      const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
-      userLikedIds = new Set(
-        likedApiData.map((item) => item.performanceId || item.id)
-      );
-    } catch (err) {}
 
     const API_ENDPOINT = "/festivals/custom";
 
@@ -107,8 +107,9 @@ const TimetableMainPage = () => {
 
       const transformedData: FestivalItem[] = apiData.map((item) => ({
         id: item.id,
+        mt20id: item.mt20id,
         title: item.prfnm,
-        isLiked: userLikedIds.has(item.id),
+        isLiked: likedIds.has(item.id), 
         location: item.fcltynm,
         date: `${item.prfpdfrom.replace(/-/g, ".")} - ${item.prfpdto
           .slice(5)
@@ -127,18 +128,9 @@ const TimetableMainPage = () => {
     }
   }, []);
 
-  const fetchMoreFestivals = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    let userLikedIds: Set<number> = new Set();
-    try {
-      const likesResponse = await api.get("/likes/my/festivals");
-      const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
-      userLikedIds = new Set(
-        likedApiData.map((item) => item.performanceId || item.id)
-      );
-    } catch (err) {}
+  const fetchMoreFestivals = useCallback(async (likedIds: Set<number>) => {
+    setIsMoreLoading(true);
+    setMoreError(null);
 
     try {
       const response = await api.get(`/kopis/performances/festivals`);
@@ -146,8 +138,9 @@ const TimetableMainPage = () => {
 
       const transformedData: FestivalItem[] = apiData.map((item) => ({
         id: item.id,
+        mt20id: item.mt20id,
         title: item.prfnm,
-        isLiked: userLikedIds.has(item.id),
+        isLiked: likedIds.has(item.id), 
         location: item.fcltynm,
         date: `${item.prfpdfrom.replace(/-/g, ".")} - ${item.prfpdto
           .slice(5)
@@ -157,13 +150,13 @@ const TimetableMainPage = () => {
 
       setMorefestival(transformedData);
     } catch (err) {
-      setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
+      setMoreError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
       setMorefestival([]);
     } finally {
-      setIsLoading(false);
+      setIsMoreLoading(false);
     }
   }, []);
-
+  
   const handleLikeChangeSuccess = useCallback(
     (festivalId: number, newIsLikedState: boolean) => {
       setMorefestival((prevList) =>
@@ -177,19 +170,36 @@ const TimetableMainPage = () => {
         )
       );
      
-      fetchMyFavorites(); 
+      setRecommendedFestivals((prevList) => {
+        if (newIsLikedState) {
+          const itemToAdd = morefestival.find(item => item.id === festivalId);
+          if (itemToAdd) {
+            return [
+              ...prevList,
+              {...itemToAdd, isLiked: true} as RecommendItem
+            ];
+          }
+          return prevList;
+        } else {
+          return prevList.filter(item => item.id !== festivalId) as RecommendItem[];
+        }
+      });
+      
     },
-    [fetchMyFavorites]
+    [morefestival] 
   );
-
+  
   useEffect(() => {
-    fetchMyTimetables();
-    fetchMyFavorites();
-  }, [fetchMyFavorites, fetchMyTimetables]);
+    const loadData = async () => {
+      const likedIds = await fetchUserLikedIdsAndFavorites();
+      
+      fetchMyTimetables(likedIds);
+      fetchMoreFestivals(likedIds);
+    };
 
-  useEffect(() => {
-    fetchMoreFestivals();
-  }, [fetchMoreFestivals]);
+    loadData();
+  }, [fetchUserLikedIdsAndFavorites, fetchMyTimetables, fetchMoreFestivals]);
+
 
   const myTimetableDisplayData = myTimetables;
   const recommendData = recommendedFestivals;
@@ -246,7 +256,6 @@ const TimetableMainPage = () => {
           </section>
         )}
 
-        {/* ⭐️ 관심 목록 섹션은 recommendData를 사용하므로 변경 없음 ⭐️ */}
         {(isFavoritesLoading || favoritesError || recommendData.length > 0) && (
           <section className={timetablestyles.check}>
 
@@ -298,21 +307,21 @@ const TimetableMainPage = () => {
             boldParts={[0]}
           />
 
-          {isLoading && (
+          {isMoreLoading && (
             <p className={timetablestyles.loadingText}>
               페스티벌 목록을 불러오는 중...
             </p>
           )}
 
-          {error && <p className={timetablestyles.errorText}>{error}</p>}
+          {moreError && <p className={timetablestyles.errorText}>{moreError}</p>}
 
-          {!isLoading && !error && displayFestivalData.length > 0 && (
+          {!isMoreLoading && !moreError && displayFestivalData.length > 0 && (
             <ul className={timetablestyles.timetableList}>
               {displayFestivalData.map((item) => (
                 <FestivalListItem
                   key={item.id}
                   itemData={item}
-                  onClick={() => handleCustomizeClick(item.id)}
+                  onClick={() => handleConcertDetailClick(item.mt20id)} 
                   onLikeChangeSuccess={(id, newState) =>
                     handleLikeChangeSuccess(id, newState)
                   }
@@ -321,7 +330,7 @@ const TimetableMainPage = () => {
             </ul>
           )}
 
-          {!isLoading && !error && displayFestivalData.length === 0 && (
+          {!isMoreLoading && !moreError && displayFestivalData.length === 0 && (
             <p className={timetablestyles.noDataText}>
               해당 조건에 맞는 페스티벌이 없습니다.
             </p>

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableMainPage.tsx (날짜 형식 수정 최종 버전)
+// src/pages/timetable/TimetableMainPage.tsx (정렬 옵션 제거 완료 버전)
 
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -7,111 +7,121 @@ import FestivalListItem from "../../components/timetable/FestivalListItem";
 import SectionHeader from "../../components/SectionHeader";
 import RecommendCard from "../../components/timetable/RecommendCard";
 import Alarm from "../../components/Alarm";
-import api from "../../api/api"; 
+import api from "../../api/api"; 
+import BandCardName from "../../components/BandCardName";
 
 // ⭐️ [가정] API 응답 타입 ⭐️
 export interface KopisFestivalItem {
-  id: number;
-  mt20id: string; 
-  prfnm: string; 
-  prfpdfrom: string; // 시작일 (YYYY-MM-DD)
-  prfpdto: string;   // 종료일 (YYYY-MM-DD)
-  fcltynm: string; 
-  poster: string; 
-  
-  performanceId?: number; 
-  title?: string; 
-  posterUrl?: string; 
-  
-  newstate?: boolean; 
-  isLiked?: boolean; // 이전 필드는 옵셔널로 유지
-  likeCount?: number; 
+  id: number;
+  mt20id: string; 
+  prfnm: string; 
+  prfpdfrom: string; 
+  prfpdto: string; 
+  fcltynm: string; 
+  poster: string; 
+  
+  performanceId?: number; 
+  title?: string; 
+  posterUrl?: string; 
+  
+  newstate?: boolean; 
+  isLiked?: boolean; // 이전 필드는 옵셔널로 유지
+  likeCount?: number; 
 }
 
 // ⭐️ [UI 타입] 최종 FestivalItem 타입 ⭐️
 export interface FestivalItem {
-  id: number;
-  title: string;
-  isLiked: boolean; 
-  location: string;
-  date: string; // YYYY.MM.DD - MM.DD 형식으로 저장됨
-  thumbnailUrl: string;
+  id: number;
+  title: string;
+  isLiked: boolean; 
+  location: string;
+  date: string; // YYYY.MM.DD - MM.DD 형식
+  thumbnailUrl: string;
 }
 
 // ⭐️ [RecommendItem 타입] FestivalItem과 동일한 구조를 가집니다. ⭐️
 export interface RecommendItem extends FestivalItem {}
 
-const sortOptions = [
-  { label: "최신 등록순", key: "latest" },
-  { label: "인기순", key: "likes" },
-  { label: "예매 임박순", key: "deadline" },
-];
+// ⚠️ 정렬 옵션 배열 (sortOptions) 제거 ⚠️
+
 
 const TimetableMainPage = () => {
-  const navigate = useNavigate();
-  
-  const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
-  const [myFavorites, setMyFavorites] = useState<FestivalItem[]>([]); 
-  const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]); 
-  
-  const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
-  const [currentSort, setCurrentSort] = useState(sortOptions[0].key); 
-  
-  const [isLoading, setIsLoading] = useState(false);
-  const [isMyListLoading, setIsMyListLoading] = useState(true); 
-  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false); 
-  
-  const [error, setError] = useState<string | null>(null);
-  const [myListError, setMyListError] = useState<string | null>(null); 
-  const [favoritesError, setFavoritesError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  
+  const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
+  const [myFavorites, setMyFavorites] = useState<FestivalItem[]>([]); 
+  const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]); 
+  
+  const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
+  // ⚠️ currentSort, setCurrentSort 상태 제거 ⚠️
+  
+  const [isLoading, setIsLoading] = useState(false);
+  const [isMyListLoading, setIsMyListLoading] = useState(true); 
+  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false); 
+  
+  const [error, setError] = useState<string | null>(null);
+  const [myListError, setMyListError] = useState<string | null>(null); 
+  const [favoritesError, setFavoritesError] = useState<string | null>(null);
+
+  
+  const handleCustomizeClick = (festivalId: number) => { 
+    navigate(`/main/timetable/customize/${festivalId}`);
+  };
+
+  const handleMyTimetableClick = (festivalId: number) => { 
+    navigate(`/main/timetable/my/${festivalId}`);
+  };
+
+
+  // ⭐️ 나의 관심 페스티벌 목록 조회 (좋아요 목록) ⭐️
+  const fetchMyFavorites = useCallback(async () => {
+    setIsFavoritesLoading(true);
+    setFavoritesError(null);
+    const API_ENDPOINT = '/likes/my/festivals'; 
+    
+    try {
+      const response = await api.get(API_ENDPOINT); 
+      const apiData: any[] = response.data.data || response.data; 
+      
+      const transformedData: FestivalItem[] = apiData.map(item => ({
+          id: item.performanceId,
+          title: item.title,
+          isLiked: true, // 이 목록은 무조건 좋아요 상태임
+          location: item.fcltynm,
+          // ⚠️ 날짜 형식 수정 재적용
+          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
+          thumbnailUrl: item.posterUrl,
+      }));
+
+      setMyFavorites(transformedData); 
+      setRecommendedFestivals(transformedData as RecommendItem[]); 
+      
+    } catch (err) {
+      console.error(`❌ 나의 관심 페스티벌 목록 로드 중 오류 발생:`, err);
+      setFavoritesError("관심 목록을 불러오는 데 실패했습니다.");
+      setMyFavorites([]);
+      setRecommendedFestivals([]);
+    } finally {
+      setIsFavoritesLoading(false);
+    }
+  }, []); 
 
   
-  const handleCustomizeClick = (festivalId: number) => { 
-    navigate(`/main/timetable/customize/${festivalId}`);
-  };
-
-  const handleMyTimetableClick = (festivalId: number) => { 
-    navigate(`/main/timetable/my/${festivalId}`);
-  };
-
-
-  // ⭐️ 나의 관심 페스티벌 목록 조회 (좋아요 목록) ⭐️
-  const fetchMyFavorites = useCallback(async () => {
-    setIsFavoritesLoading(true);
-    setFavoritesError(null);
-    const API_ENDPOINT = '/likes/my/festivals'; 
-    
-    try {
-      const response = await api.get(API_ENDPOINT); 
-      const apiData: any[] = response.data.data || response.data; 
-      
-      const transformedData: FestivalItem[] = apiData.map(item => ({
-          id: item.performanceId,
-          title: item.title,
-          isLiked: true, 
-          location: item.fcltynm,
-          // ⚠️ 날짜 형식 수정 적용
-          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
-          thumbnailUrl: item.posterUrl,
-      }));
-
-      setMyFavorites(transformedData); 
-      setRecommendedFestivals(transformedData as RecommendItem[]); 
-      
-    } catch (err) {
-      console.error(`❌ 나의 관심 페스티벌 목록 로드 중 오류 발생:`, err);
-      setFavoritesError("관심 목록을 불러오는 데 실패했습니다.");
-      setMyFavorites([]);
-      setRecommendedFestivals([]);
-    } finally {
-      setIsFavoritesLoading(false);
-    }
-  }, []); 
-
-  
+  // ⭐️⭐️ [FIX] 나의 타임테이블 목록 조회 (좋아요 상태 병합 로직 추가) ⭐️⭐️
   const fetchMyTimetables = useCallback(async () => {
     setIsMyListLoading(true);
     setMyListError(null);
+    
+    // 1. 좋아요 상태 확인을 위해 사용자의 관심 목록 ID를 가져옵니다.
+    let userLikedIds: Set<number> = new Set();
+    try {
+        const likesResponse = await api.get('/likes/my/festivals');
+        const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
+        // API 응답의 performanceId (혹은 id)를 사용하여 좋아요 ID 목록을 만듭니다.
+        userLikedIds = new Set(likedApiData.map(item => item.performanceId || item.id)); 
+    } catch (err) {
+        console.warn("⚠️ My Timetables: 좋아요 목록 로드 실패, 기본 isLiked=false로 진행됩니다.");
+    }
     
     const API_ENDPOINT = '/festivals/custom'; 
     
@@ -122,9 +132,10 @@ const TimetableMainPage = () => {
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.id,
           title: item.prfnm,
-          isLiked: item.isLiked ?? item.newstate ?? false, 
+          // ⭐️ FIX: 좋아요 ID 목록에 현재 item.id가 포함되어 있는지 확인하여 isLiked를 설정합니다. ⭐️
+          isLiked: userLikedIds.has(item.id), 
           location: item.fcltynm, 
-          // ⚠️ 날짜 형식 수정 적용
+          // ⚠️ 날짜 형식 수정 재적용
           date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
           thumbnailUrl: item.poster, 
       }));
@@ -140,197 +151,194 @@ const TimetableMainPage = () => {
   }, []);
 
 
-  // ⭐️ 더 많은 페스티벌 목록 조회 (좋아요 상태 영구 유지를 위해 사용자 좋아요 정보 병합) ⭐️
-  const fetchMoreFestivals = useCallback(async (sortKey: string) => {
-    setIsLoading(true);
-    setError(null);
-    
-    // 1. 좋아요 상태 확인을 위해 사용자의 관심 목록 ID를 가져옵니다.
-    let userLikedIds: Set<number> = new Set();
-    try {
-        const likesResponse = await api.get('/likes/my/festivals');
-        const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
-        userLikedIds = new Set(likedApiData.map(item => item.performanceId || item.id)); 
-    } catch (err) {
-        console.warn("⚠️ 관심 목록 로드 실패: 메인 목록은 기본 isLiked=false로 진행됩니다.");
-    }
+  // ⭐️ 더 많은 페스티벌 목록 조회 (sortKey 매개변수 제거) ⭐️
+  const fetchMoreFestivals = useCallback(async () => { // ⚠️ sortKey 매개변수 제거
+    setIsLoading(true);
+    setError(null);
+    
+    // 1. 좋아요 상태 확인을 위해 사용자의 관심 목록 ID를 가져옵니다.
+    let userLikedIds: Set<number> = new Set();
+    try {
+        const likesResponse = await api.get('/likes/my/festivals');
+        const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
+        // API 응답의 performanceId (혹은 id)를 사용하여 좋아요 ID 목록을 만듭니다.
+        userLikedIds = new Set(likedApiData.map(item => item.performanceId || item.id)); 
+    } catch (err) {
+        // 관심 목록 로드 실패 시에도 메인 목록은 계속 로드합니다.
+        console.warn("⚠️ 관심 목록 로드 실패: 메인 목록은 기본 isLiked=false로 진행됩니다.");
+    }
 
-    try {
-        // 2. 메인 페스티벌 목록을 가져옵니다.
-        const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
-        const apiData: KopisFestivalItem[] = response.data.data || response.data; 
-        
-        // 3. 메인 목록에 사용자 좋아요 상태를 병합(Merge)합니다.
-        const transformedData: FestivalItem[] = apiData.map(item => ({
-            id: item.id,
-            title: item.prfnm, 
-            isLiked: userLikedIds.has(item.id), 
-            location: item.fcltynm, 
-            // ⚠️ 날짜 형식 수정 적용
-            date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
-            thumbnailUrl: item.poster, 
-        }));
+    try {
+        // 2. 메인 페스티벌 목록을 가져옵니다. (정렬 파라미터 제거)
+        const response = await api.get(`/kopis/performances/festivals`); // ⚠️ ?sort=${sortKey} 제거
+        const apiData: KopisFestivalItem[] = response.data.data || response.data; 
+        
+        // 3. 메인 목록에 사용자 좋아요 상태를 병합(Merge)합니다.
+        const transformedData: FestivalItem[] = apiData.map(item => ({
+            id: item.id,
+            title: item.prfnm, 
+            // ⭐️ 좋아요 ID 목록에 현재 item.id가 포함되어 있는지 확인하여 isLiked를 설정합니다. ⭐️
+            isLiked: userLikedIds.has(item.id), 
+            location: item.fcltynm, 
+            // ⚠️ 날짜 형식 수정 재적용
+            date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
+            thumbnailUrl: item.poster, 
+        }));
 
-        setMorefestival(transformedData);
-        
-    } catch (err) {
-        console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
-        setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
-        setMorefestival([]);
-    } finally {
-        setIsLoading(false);
-    }
-  }, []); 
-
-
-  // 좋아요 상태 변경 성공 콜백: 모든 목록에 로컬 업데이트를 적용합니다.
-  const handleLikeChangeSuccess = useCallback((festivalId: number, newIsLikedState: boolean) => {
-    
-    // 1. '더 많은 페스티벌' 목록 (morefestival) 로컬 업데이트 (즉시 반영)
-    setMorefestival(prevList => {
-        const newList = prevList.map(item => 
-            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
-        );
-        return newList;
-    });
-    
-    // 2. '나의 타임테이블' 목록 (myTimetables) 로컬 업데이트 (즉시 반영)
-    setMyTimetables(prevList => {
-        const newList = prevList.map(item => 
-            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
-        );
-        return newList;
-    });
-    
-    // 3. '나의 관심 페스티벌' 목록을 API로 새로고침 (이 목록은 항목 자체가 추가/제거되므로 API 호출이 필요)
-    fetchMyFavorites(); 
-    
-  }, [fetchMyFavorites]);
+        setMorefestival(transformedData);
+        
+    } catch (err) {
+        console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
+        setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
+        setMorefestival([]);
+    } finally {
+        setIsLoading(false);
+    }
+  }, []); // ⚠️ 의존성 배열에서 currentSort 제거
 
 
-  useEffect(() => {
-    fetchMyTimetables();
-    fetchMyFavorites(); 
-  }, [fetchMyFavorites, fetchMyTimetables]); 
-  
-  useEffect(() => {
-    fetchMoreFestivals(currentSort);
-  }, [currentSort, fetchMoreFestivals]); 
+  // 좋아요 상태 변경 성공 콜백: 모든 목록에 로컬 업데이트를 적용하고, 불필요한 API 호출을 제거합니다.
+  const handleLikeChangeSuccess = useCallback((festivalId: number, newIsLikedState: boolean) => {
+    
+    // 1. '더 많은 페스티벌' 목록 (morefestival) 로컬 업데이트 (즉시 반영)
+    setMorefestival(prevList => {
+        const newList = prevList.map(item => 
+            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
+        );
+        return newList;
+    });
+    
+    // 2. '나의 타임테이블' 목록 (myTimetables) 로컬 업데이트 (즉시 반영)
+    setMyTimetables(prevList => {
+        const newList = prevList.map(item => 
+            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
+        );
+        return newList;
+    });
+    
+    // 3. '나의 관심 페스티벌' 목록은 항목 자체가 추가/제거되므로 API로 새로고침
+    fetchMyFavorites(); 
+    
+  }, [fetchMyFavorites]);
 
 
-  const myTimetableDisplayData = myTimetables; 
-  const recommendData = recommendedFestivals; 
-  const displayFestivalData = morefestival; 
+  useEffect(() => {
+    // 마운트 시 나의 타임테이블과 관심 목록을 불러옵니다.
+    fetchMyTimetables(); 
+    fetchMyFavorites(); 
+  }, [fetchMyFavorites, fetchMyTimetables]); 
+  
+  useEffect(() => {
+    // 마운트 시 메인 목록을 불러옵니다. (정렬 옵션 제거됨)
+    fetchMoreFestivals(); // ⚠️ currentSort 대신 직접 호출
+  }, [fetchMoreFestivals]); 
 
-  return (
-    <>
-       <Alarm></Alarm>
-      <div className={timetablestyles.mainContentWrapper}>
-        
-        {/* --- 1. 나의 타임테이블 섹션 --- */}
-        <section className={timetablestyles.mytimetableSection}>
-          <SectionHeader
-            subtitle="공연 관람이 며칠 안 남았다면?"
-            mainTitleLines={["나의\u00A0", "타임테이블"]}
-            boldParts={[1]}
-          />
-          {isMyListLoading && <p className={timetablestyles.loadingText}>나의 타임테이블을 불러오는 중...</p>}
-          {myListError && <p className={timetablestyles.errorText}>{myListError}</p>}
 
-          {!isMyListLoading && !myListError && myTimetableDisplayData.length > 0 && (
-            <ul className={timetablestyles.timetableList}>
-              {myTimetableDisplayData.map((item) => (
-                <FestivalListItem
-                  key={item.id}
-                  itemData={item}
-                  onClick={() => handleMyTimetableClick(item.id)}
-                  onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
-                />
-              ))}
-            </ul>
-          )}
-          
-          {!isMyListLoading && !myListError && myTimetableDisplayData.length === 0 && (
-            <p className={timetablestyles.noDataText}>나만의 타임테이블을 만들어 보세요!</p>
-          )}
-        </section>
+  const myTimetableDisplayData = myTimetables; 
+  const recommendData = recommendedFestivals; 
+  const displayFestivalData = morefestival; 
 
-        
-        {/* --- 2. 나의 관심 페스티벌의 타임테이블 확인하기 --- */}
-        <section className={timetablestyles.check}>
-          <SectionHeader
-            subtitle="나의 관심 페스티벌의"
-            mainTitleLines={["타임테이블\u00A0", "확인하기"]}
-            boldParts={[0]}
-          />
+  return (
+    <>
+        <Alarm />
+      
+      <div className={timetablestyles.mainContentWrapper}>
+        
+        {/* --- 1. 나의 타임테이블 섹션 --- */}
+        {(isMyListLoading || myListError || myTimetableDisplayData.length > 0) && (
+          <section className={timetablestyles.mytimetableSection}>
+            <SectionHeader
+              subtitle="공연 관람이 며칠 안 남았다면?"
+              mainTitleLines={["나의\u00A0", "타임테이블"]}
+              boldParts={[1]}
+            />
+            {isMyListLoading && <p className={timetablestyles.loadingText}>나의 타임테이블을 불러오는 중...</p>}
+            {myListError && <p className={timetablestyles.errorText}>{myListError}</p>}
 
-          {isFavoritesLoading && <p className={timetablestyles.loadingText}>관심 목록을 불러오는 중...</p>}
-          {favoritesError && <p className={timetablestyles.errorText}>{favoritesError}</p>}
-          
-          {!isFavoritesLoading && !favoritesError && recommendData.length > 0 && (
-            <div className={timetablestyles.recommendListWrapper}>
-              {recommendData.map((item) => (
-                <RecommendCard
-                  key={item.id}
-                  itemData={item} 
-                  onCustomizeClick={() => handleCustomizeClick(item.id)}
-                />
-              ))}
-            </div>
-          )}
-          
-          {!isFavoritesLoading && !favoritesError && recommendData.length === 0 && (
-            <p className={timetablestyles.noDataText}>관심 페스티벌 데이터가 없습니다.</p>
-          )}
-        </section>
-        {/* --- */}
+            {!isMyListLoading && !myListError && myTimetableDisplayData.length > 0 && (
+              <ul className={timetablestyles.timetableList}>
+                {myTimetableDisplayData.map((item) => (
+                  <FestivalListItem
+                    key={item.id}
+                    itemData={item}
+                    onClick={() => handleMyTimetableClick(item.id)}
+                    onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
+                  />
+                ))}
+              </ul>
+            )}
+          
+            {!isMyListLoading && !myListError && myTimetableDisplayData.length === 0 && (
+              <p className={timetablestyles.noDataText}>나만의 타임테이블을 만들어 보세요!</p>
+            )}
+          </section>
+        )}
+        
+        {/* --- 2. 나의 관심 페스티벌의 타임테이블 확인하기 --- */}
+        {(isFavoritesLoading || favoritesError || recommendData.length > 0) && (
+          <section className={timetablestyles.check}>
+            <SectionHeader
+              subtitle="나의 관심 페스티벌의"
+              mainTitleLines={["타임테이블\u00A0", "확인하기"]}
+              boldParts={[0]}
+            />
 
-        {/* --- 3. 더 많은 페스티벌 섹션 --- */}
-        <section className={timetablestyles.moretimetableSection}>
-          <SectionHeader
-            subtitle="더 많은 페스티벌의"
-            mainTitleLines={["타임테이블", "을\u00A0확인해\u00A0보세요!"]}
-            boldParts={[0]}
-          />
-          
-          <div className={timetablestyles.sortOptions}>
-            {sortOptions.map((option) => (
-              <span
-                key={option.key}
-                className={`${timetablestyles.sortButton} ${
-                  currentSort === option.key ? timetablestyles.active : ""
-                }`}
-                onClick={() => setCurrentSort(option.key)}
-              >
-                {option.label}
-              </span>
-            ))}
-          </div>
-          
-          {isLoading && <p className={timetablestyles.loadingText}>페스티벌 목록을 불러오는 중...</p>}
-          {error && <p className={timetablestyles.errorText}>{error}</p>}
-          
-          {!isLoading && !error && displayFestivalData.length > 0 && (
-            <ul className={timetablestyles.timetableList}>
-              {displayFestivalData.map((item) => (
-                <FestivalListItem
-                  key={item.id}
-                  itemData={item}
-                  onClick={() => handleCustomizeClick(item.id)}
-                  onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
-                />
-              ))}
-            </ul>
-          )}
-          
-          {!isLoading && !error && displayFestivalData.length === 0 && (
-            <p className={timetablestyles.noDataText}>해당 조건에 맞는 페스티벌이 없습니다.</p>
-          )}
+            {isFavoritesLoading && <p className={timetablestyles.loadingText}>관심 목록을 불러오는 중...</p>}
+            {favoritesError && <p className={timetablestyles.errorText}>{favoritesError}</p>}
+          
+            {!isFavoritesLoading && !favoritesError && recommendData.length > 0 && (
+              <div className={timetablestyles.recommendListWrapper}>
+                {recommendData.map((item) => (
+                  <RecommendCard
+                    key={item.id}
+                    itemData={item} 
+                    onCustomizeClick={() => handleCustomizeClick(item.id)}
+                  />
+                ))}
+              </div>
+            )}
+          
+            {!isFavoritesLoading && !favoritesError && recommendData.length === 0 && (
+              <p className={timetablestyles.noDataText}>관심 페스티벌 데이터가 없습니다.</p>
+            )}
+          </section>
+        )}
+        {/* --- */}
 
-        </section>
-      </div>
-    </>
-  );
+        {/* --- 3. 더 많은 페스티벌 섹션 --- */}
+        <section className={timetablestyles.moretimetableSection}>
+          <SectionHeader
+            subtitle="더 많은 페스티벌의"
+            mainTitleLines={["타임테이블", "을\u00A0확인해\u00A0보세요!"]}
+            boldParts={[0]}
+          />
+          
+          {/* ⚠️ 정렬 옵션 UI 제거 ⚠️ */}
+         
+          {isLoading && <p className={timetablestyles.loadingText}>페스티벌 목록을 불러오는 중...</p>}
+          {error && <p className={timetablestyles.errorText}>{error}</p>}
+          
+          {!isLoading && !error && displayFestivalData.length > 0 && (
+            <ul className={timetablestyles.timetableList}>
+              {displayFestivalData.map((item) => (
+                <FestivalListItem
+                  key={item.id}
+                  itemData={item}
+                  onClick={() => handleCustomizeClick(item.id)}
+                  onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
+                />
+              ))}
+            </ul>
+          )}
+          
+          {!isLoading && !error && displayFestivalData.length === 0 && (
+            <p className={timetablestyles.noDataText}>해당 조건에 맞는 페스티벌이 없습니다.</p>
+          )}
+
+        </section>
+      </div>
+    </>
+  );
 };
 
 export default TimetableMainPage;

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/timetable/TimetableMainPage.tsx (최종 수정: 좋아요 목록 섹션 제거 및 데이터 흐름 변경)
+// src/pages/timetable/TimetableMainPage.tsx (전체 코드 - likeCount 제거 후)
 
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -24,14 +24,14 @@ export interface KopisFestivalItem {
   posterUrl?: string; 
 
   isLiked?: boolean; 
-  likeCount?: number; 
+  likeCount?: number; // API 응답에는 포함될 수 있지만, UI 로직에서는 사용하지 않음
 }
 
-// ⭐️ [UI 타입] 최종 FestivalItem 타입 ⭐️
+// ⭐️ [UI 타입] 최종 FestivalItem 타입 (likeCount 제거) ⭐️
 export interface FestivalItem {
   id: number;
   title: string;
-  likeCount: number; 
+  // likeCount: number; // UI에서 사용하지 않으므로 제거
   isLiked: boolean; 
   location: string;
   date: string; 
@@ -51,10 +51,7 @@ const TimetableMainPage = () => {
   const navigate = useNavigate();
   
   const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
-  // myFavorites 상태는 데이터를 가져오는 역할만 합니다.
   const [myFavorites, setMyFavorites] = useState<FestivalItem[]>([]); 
-  
-  // ⭐️ recommendedFestivals는 myFavorites 데이터를 받아 RecommendCard에 표시합니다. ⭐️
   const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]); 
   
   const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
@@ -62,7 +59,7 @@ const TimetableMainPage = () => {
   
   const [isLoading, setIsLoading] = useState(false);
   const [isMyListLoading, setIsMyListLoading] = useState(true); 
-  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false); // 로딩 상태는 유지
+  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false); 
   
   const [error, setError] = useState<string | null>(null);
   const [myListError, setMyListError] = useState<string | null>(null); 
@@ -91,16 +88,14 @@ const TimetableMainPage = () => {
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.performanceId,
           title: item.title,
-          likeCount: 0, 
-          isLiked: true, 
+          isLiked: true, // 이 목록은 무조건 좋아요 상태임
           location: item.fcltynm,
           date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
           thumbnailUrl: item.posterUrl,
       }));
 
-      // ⭐️ 핵심 변경: myFavorites와 recommendedFestivals를 모두 업데이트 ⭐️
       setMyFavorites(transformedData); 
-      setRecommendedFestivals(transformedData as RecommendItem[]); // 데이터를 RecommendCard 섹션으로 전달
+      setRecommendedFestivals(transformedData as RecommendItem[]); 
       
     } catch (err) {
       console.error(`❌ 나의 관심 페스티벌 목록 로드 중 오류 발생:`, err);
@@ -116,7 +111,7 @@ const TimetableMainPage = () => {
   const fetchMyTimetables = async () => {
     setIsMyListLoading(true);
     setMyListError(null);
-    // ... (나의 타임테이블 로직 유지) ...
+    
     const API_ENDPOINT = '/festivals/custom'; 
     
     try {
@@ -126,7 +121,6 @@ const TimetableMainPage = () => {
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.id,
           title: item.prfnm,
-          likeCount: item.likeCount || 0, 
           isLiked: item.isLiked || false, 
           location: item.fcltynm, 
           date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
@@ -150,13 +144,13 @@ const TimetableMainPage = () => {
     setError(null);
     
     try {
+      // ⭐️ 핵심 GET 요청: 이 응답에서 isLiked가 true로 와야 함 ⭐️
       const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
       const apiData: KopisFestivalItem[] = response.data; 
       
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.id,
           title: item.prfnm, 
-          likeCount: item.likeCount || 0, 
           isLiked: item.isLiked || false, 
           location: item.fcltynm, 
           date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
@@ -177,17 +171,15 @@ const TimetableMainPage = () => {
 
   // 좋아요 상태 변경 시 목록 전체 새로고침 콜백
   const handleLikeChangeSuccess = useCallback(() => {
-    // 좋아요 상태가 변경되면, 모든 목록을 새로고침하여 isLiked 상태를 동기화합니다.
-    fetchMyFavorites(); // 이 호출이 recommendedFestivals를 새로고침합니다.
+    // 좋아요가 성공하면 관련 목록을 모두 새로고침
+    fetchMyFavorites(); 
     fetchMoreFestivals(currentSort); 
   }, [fetchMyFavorites, fetchMoreFestivals, currentSort]);
 
 
   useEffect(() => {
     fetchMyTimetables();
-    // ⭐️ 좋아요 목록을 가져와 recommendedFestivals에 설정 ⭐️
     fetchMyFavorites(); 
-    
   }, [fetchMyFavorites]); 
   
   useEffect(() => {
@@ -196,7 +188,7 @@ const TimetableMainPage = () => {
 
 
   const myTimetableDisplayData = myTimetables; 
-  const recommendData = recommendedFestivals; // 좋아요 목록 데이터
+  const recommendData = recommendedFestivals; 
   const displayFestivalData = morefestival; 
 
   return (
@@ -204,7 +196,7 @@ const TimetableMainPage = () => {
        <Alarm></Alarm>
       <div className={timetablestyles.mainContentWrapper}>
         
-        {/* --- 1. 나의 타임테이블 섹션 (유지) --- */}
+        {/* --- 1. 나의 타임테이블 섹션 --- */}
         <section className={timetablestyles.mytimetableSection}>
           <SectionHeader
             subtitle="공연 관람이 며칠 안 남았다면?"
@@ -233,10 +225,7 @@ const TimetableMainPage = () => {
         </section>
 
         
-        {/* ❌ 2. 나의 관심 페스티벌 섹션 (제거 완료) ❌ */}
-
-        
-        {/* --- 3. 나의 관심 페스티벌의 타임테이블 확인하기 (RecommendCard로 좋아요 목록 표시) --- */}
+        {/* --- 2. 나의 관심 페스티벌의 타임테이블 확인하기 --- */}
         <section className={timetablestyles.check}>
           <SectionHeader
             subtitle="나의 관심 페스티벌의"
@@ -247,13 +236,12 @@ const TimetableMainPage = () => {
           {isFavoritesLoading && <p className={timetablestyles.loadingText}>관심 목록을 불러오는 중...</p>}
           {favoritesError && <p className={timetablestyles.errorText}>{favoritesError}</p>}
           
-          {/* 좋아요 목록이 로드되면 RecommendCard로 표시 */}
           {!isFavoritesLoading && !favoritesError && recommendData.length > 0 && (
             <div className={timetablestyles.recommendListWrapper}>
               {recommendData.map((item) => (
                 <RecommendCard
                   key={item.id}
-                  itemData={item} // 좋아요 목록 데이터
+                  itemData={item} 
                   onCustomizeClick={() => handleCustomizeClick(item.id)}
                 />
               ))}
@@ -266,7 +254,7 @@ const TimetableMainPage = () => {
         </section>
         {/* --- */}
 
-        {/* --- 4. 더 많은 페스티벌 섹션 (유지) --- */}
+        {/* --- 3. 더 많은 페스티벌 섹션 --- */}
         <section className={timetablestyles.moretimetableSection}>
           <SectionHeader
             subtitle="더 많은 페스티벌의"

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,5 +1,3 @@
-// src/pages/timetable/TimetableMainPage.tsx (정렬 옵션 제거 완료 버전)
-
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import timetablestyles from "../../css/pages/timetable/timetablemain.module.css";
@@ -7,338 +5,331 @@ import FestivalListItem from "../../components/timetable/FestivalListItem";
 import SectionHeader from "../../components/SectionHeader";
 import RecommendCard from "../../components/timetable/RecommendCard";
 import Alarm from "../../components/Alarm";
-import api from "../../api/api"; 
-import BandCardName from "../../components/BandCardName";
+import api from "../../api/api";
 
-// ⭐️ [가정] API 응답 타입 ⭐️
 export interface KopisFestivalItem {
-  id: number;
-  mt20id: string; 
-  prfnm: string; 
-  prfpdfrom: string; 
-  prfpdto: string; 
-  fcltynm: string; 
-  poster: string; 
-  
-  performanceId?: number; 
-  title?: string; 
-  posterUrl?: string; 
-  
-  newstate?: boolean; 
-  isLiked?: boolean; // 이전 필드는 옵셔널로 유지
-  likeCount?: number; 
+  id: number;
+  mt20id: string;
+  prfnm: string;
+  prfpdfrom: string;
+  prfpdto: string;
+  fcltynm: string;
+  poster: string;
+  performanceId?: number;
+  title?: string;
+  posterUrl?: string;
+  newstate?: boolean;
+  isLiked?: boolean;
+  likeCount?: number;
 }
 
-// ⭐️ [UI 타입] 최종 FestivalItem 타입 ⭐️
 export interface FestivalItem {
-  id: number;
-  title: string;
-  isLiked: boolean; 
-  location: string;
-  date: string; // YYYY.MM.DD - MM.DD 형식
-  thumbnailUrl: string;
+  id: number;
+  title: string;
+  isLiked: boolean;
+  location: string;
+  date: string;
+  thumbnailUrl: string;
 }
 
-// ⭐️ [RecommendItem 타입] FestivalItem과 동일한 구조를 가집니다. ⭐️
 export interface RecommendItem extends FestivalItem {}
 
-// ⚠️ 정렬 옵션 배열 (sortOptions) 제거 ⚠️
-
-
 const TimetableMainPage = () => {
-  const navigate = useNavigate();
-  
-  const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
-  const [myFavorites, setMyFavorites] = useState<FestivalItem[]>([]); 
-  const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]); 
-  
-  const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
-  // ⚠️ currentSort, setCurrentSort 상태 제거 ⚠️
-  
-  const [isLoading, setIsLoading] = useState(false);
-  const [isMyListLoading, setIsMyListLoading] = useState(true); 
-  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false); 
-  
-  const [error, setError] = useState<string | null>(null);
-  const [myListError, setMyListError] = useState<string | null>(null); 
-  const [favoritesError, setFavoritesError] = useState<string | null>(null);
-
-  
-  const handleCustomizeClick = (festivalId: number) => { 
-    navigate(`/main/timetable/customize/${festivalId}`);
-  };
-
-  const handleMyTimetableClick = (festivalId: number) => { 
-    navigate(`/main/timetable/my/${festivalId}`);
-  };
-
-
-  // ⭐️ 나의 관심 페스티벌 목록 조회 (좋아요 목록) ⭐️
-  const fetchMyFavorites = useCallback(async () => {
-    setIsFavoritesLoading(true);
-    setFavoritesError(null);
-    const API_ENDPOINT = '/likes/my/festivals'; 
-    
-    try {
-      const response = await api.get(API_ENDPOINT); 
-      const apiData: any[] = response.data.data || response.data; 
-      
-      const transformedData: FestivalItem[] = apiData.map(item => ({
-          id: item.performanceId,
-          title: item.title,
-          isLiked: true, // 이 목록은 무조건 좋아요 상태임
-          location: item.fcltynm,
-          // ⚠️ 날짜 형식 수정 재적용
-          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
-          thumbnailUrl: item.posterUrl,
-      }));
-
-      setMyFavorites(transformedData); 
-      setRecommendedFestivals(transformedData as RecommendItem[]); 
-      
-    } catch (err) {
-      console.error(`❌ 나의 관심 페스티벌 목록 로드 중 오류 발생:`, err);
-      setFavoritesError("관심 목록을 불러오는 데 실패했습니다.");
-      setMyFavorites([]);
-      setRecommendedFestivals([]);
-    } finally {
-      setIsFavoritesLoading(false);
-    }
-  }, []); 
-
+  const navigate = useNavigate();
+  const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
+  const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]);
+  const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isMyListLoading, setIsMyListLoading] = useState(true);
+  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [myListError, setMyListError] = useState<string | null>(null);
+  const [favoritesError, setFavoritesError] = useState<string | null>(null);
   
-  // ⭐️⭐️ [FIX] 나의 타임테이블 목록 조회 (좋아요 상태 병합 로직 추가) ⭐️⭐️
+
+
+  const handleCustomizeClick = (festivalId: number) => {
+    navigate(`/main/timetable/customize/${festivalId}`);
+  };
+
+  const handleMyTimetableClick = (festivalId: number) => {
+    navigate(`/main/timetable/my/${festivalId}`);
+  };
+
+
+  const fetchMyFavorites = useCallback(async () => {
+    setIsFavoritesLoading(true);
+    setFavoritesError(null);
+    const API_ENDPOINT = "/likes/my/festivals";
+    try {
+      const response = await api.get(API_ENDPOINT);
+      const apiData: any[] = response.data.data || response.data;
+      const transformedData: FestivalItem[] = apiData.map((item) => ({
+        id: item.performanceId,
+        title: item.title,
+        isLiked: true,
+        location: item.fcltynm,
+        date: `${item.prfpdfrom.replace(/-/g, ".")} - ${item.prfpdto
+          .slice(5)
+          .replace(/-/g, ".")}`,
+        thumbnailUrl: item.posterUrl,
+      }));
+
+    
+      setRecommendedFestivals(transformedData as RecommendItem[]);
+    } catch (err) {
+      setFavoritesError("관심 목록을 불러오는 데 실패했습니다.");
+
+      setRecommendedFestivals([]);
+    } finally {
+      setIsFavoritesLoading(false);
+    }
+  }, []);
+
   const fetchMyTimetables = useCallback(async () => {
     setIsMyListLoading(true);
     setMyListError(null);
-    
-    // 1. 좋아요 상태 확인을 위해 사용자의 관심 목록 ID를 가져옵니다.
+
     let userLikedIds: Set<number> = new Set();
     try {
-        const likesResponse = await api.get('/likes/my/festivals');
-        const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
-        // API 응답의 performanceId (혹은 id)를 사용하여 좋아요 ID 목록을 만듭니다.
-        userLikedIds = new Set(likedApiData.map(item => item.performanceId || item.id)); 
-    } catch (err) {
-        console.warn("⚠️ My Timetables: 좋아요 목록 로드 실패, 기본 isLiked=false로 진행됩니다.");
-    }
-    
-    const API_ENDPOINT = '/festivals/custom'; 
-    
+      const likesResponse = await api.get("/likes/my/festivals");
+      const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
+      userLikedIds = new Set(
+        likedApiData.map((item) => item.performanceId || item.id)
+      );
+    } catch (err) {}
+
+    const API_ENDPOINT = "/festivals/custom";
+
     try {
-      const response = await api.get(API_ENDPOINT); 
-      const apiData: KopisFestivalItem[] = response.data.data || response.data; 
-      
-      const transformedData: FestivalItem[] = apiData.map(item => ({
-          id: item.id,
-          title: item.prfnm,
-          // ⭐️ FIX: 좋아요 ID 목록에 현재 item.id가 포함되어 있는지 확인하여 isLiked를 설정합니다. ⭐️
-          isLiked: userLikedIds.has(item.id), 
-          location: item.fcltynm, 
-          // ⚠️ 날짜 형식 수정 재적용
-          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
-          thumbnailUrl: item.poster, 
+      const response = await api.get(API_ENDPOINT);
+      const apiData: KopisFestivalItem[] = response.data.data || response.data;
+
+      const transformedData: FestivalItem[] = apiData.map((item) => ({
+        id: item.id,
+        title: item.prfnm,
+        isLiked: userLikedIds.has(item.id),
+        location: item.fcltynm,
+        date: `${item.prfpdfrom.replace(/-/g, ".")} - ${item.prfpdto
+          .slice(5)
+          .replace(/-/g, ".")}`,
+        thumbnailUrl: item.poster,
       }));
 
       setMyTimetables(transformedData);
     } catch (err) {
-      console.error(`❌ 나의 타임테이블 목록 (${API_ENDPOINT}) 로드 중 오류 발생:`, err);
-      setMyListError("나의 타임테이블을 불러오는 데 실패했습니다. (로그인 상태 확인)");
+      setMyListError(
+        "나의 타임테이블을 불러오는 데 실패했습니다. (로그인 상태 확인)"
+      );
       setMyTimetables([]);
     } finally {
       setIsMyListLoading(false);
     }
   }, []);
 
+  const fetchMoreFestivals = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
 
-  // ⭐️ 더 많은 페스티벌 목록 조회 (sortKey 매개변수 제거) ⭐️
-  const fetchMoreFestivals = useCallback(async () => { // ⚠️ sortKey 매개변수 제거
-    setIsLoading(true);
-    setError(null);
-    
-    // 1. 좋아요 상태 확인을 위해 사용자의 관심 목록 ID를 가져옵니다.
-    let userLikedIds: Set<number> = new Set();
-    try {
-        const likesResponse = await api.get('/likes/my/festivals');
-        const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
-        // API 응답의 performanceId (혹은 id)를 사용하여 좋아요 ID 목록을 만듭니다.
-        userLikedIds = new Set(likedApiData.map(item => item.performanceId || item.id)); 
-    } catch (err) {
-        // 관심 목록 로드 실패 시에도 메인 목록은 계속 로드합니다.
-        console.warn("⚠️ 관심 목록 로드 실패: 메인 목록은 기본 isLiked=false로 진행됩니다.");
-    }
+    let userLikedIds: Set<number> = new Set();
+    try {
+      const likesResponse = await api.get("/likes/my/festivals");
+      const likedApiData: any[] = likesResponse.data.data || likesResponse.data;
+      userLikedIds = new Set(
+        likedApiData.map((item) => item.performanceId || item.id)
+      );
+    } catch (err) {}
 
-    try {
-        // 2. 메인 페스티벌 목록을 가져옵니다. (정렬 파라미터 제거)
-        const response = await api.get(`/kopis/performances/festivals`); // ⚠️ ?sort=${sortKey} 제거
-        const apiData: KopisFestivalItem[] = response.data.data || response.data; 
-        
-        // 3. 메인 목록에 사용자 좋아요 상태를 병합(Merge)합니다.
-        const transformedData: FestivalItem[] = apiData.map(item => ({
-            id: item.id,
-            title: item.prfnm, 
-            // ⭐️ 좋아요 ID 목록에 현재 item.id가 포함되어 있는지 확인하여 isLiked를 설정합니다. ⭐️
-            isLiked: userLikedIds.has(item.id), 
-            location: item.fcltynm, 
-            // ⚠️ 날짜 형식 수정 재적용
-            date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.slice(5).replace(/-/g, '.')}`, 
-            thumbnailUrl: item.poster, 
-        }));
+    try {
+      const response = await api.get(`/kopis/performances/festivals`);
+      const apiData: KopisFestivalItem[] = response.data.data || response.data;
 
-        setMorefestival(transformedData);
-        
-    } catch (err) {
-        console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
-        setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
-        setMorefestival([]);
-    } finally {
-        setIsLoading(false);
-    }
-  }, []); // ⚠️ 의존성 배열에서 currentSort 제거
+      const transformedData: FestivalItem[] = apiData.map((item) => ({
+        id: item.id,
+        title: item.prfnm,
+        isLiked: userLikedIds.has(item.id),
+        location: item.fcltynm,
+        date: `${item.prfpdfrom.replace(/-/g, ".")} - ${item.prfpdto
+          .slice(5)
+          .replace(/-/g, ".")}`,
+        thumbnailUrl: item.poster,
+      }));
 
+      setMorefestival(transformedData);
+    } catch (err) {
+      setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
+      setMorefestival([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
-  // 좋아요 상태 변경 성공 콜백: 모든 목록에 로컬 업데이트를 적용하고, 불필요한 API 호출을 제거합니다.
-  const handleLikeChangeSuccess = useCallback((festivalId: number, newIsLikedState: boolean) => {
-    
-    // 1. '더 많은 페스티벌' 목록 (morefestival) 로컬 업데이트 (즉시 반영)
-    setMorefestival(prevList => {
-        const newList = prevList.map(item => 
-            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
-        );
-        return newList;
-    });
-    
-    // 2. '나의 타임테이블' 목록 (myTimetables) 로컬 업데이트 (즉시 반영)
-    setMyTimetables(prevList => {
-        const newList = prevList.map(item => 
-            item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
-        );
-        return newList;
-    });
-    
-    // 3. '나의 관심 페스티벌' 목록은 항목 자체가 추가/제거되므로 API로 새로고침
-    fetchMyFavorites(); 
-    
-  }, [fetchMyFavorites]);
+  const handleLikeChangeSuccess = useCallback(
+    (festivalId: number, newIsLikedState: boolean) => {
+      setMorefestival((prevList) =>
+        prevList.map((item) =>
+          item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
+        )
+      );
+      setMyTimetables((prevList) =>
+        prevList.map((item) =>
+          item.id === festivalId ? { ...item, isLiked: newIsLikedState } : item
+        )
+      );
+     
+      fetchMyFavorites(); 
+    },
+    [fetchMyFavorites]
+  );
 
+  useEffect(() => {
+    fetchMyTimetables();
+    fetchMyFavorites();
+  }, [fetchMyFavorites, fetchMyTimetables]);
 
-  useEffect(() => {
-    // 마운트 시 나의 타임테이블과 관심 목록을 불러옵니다.
-    fetchMyTimetables(); 
-    fetchMyFavorites(); 
-  }, [fetchMyFavorites, fetchMyTimetables]); 
-  
-  useEffect(() => {
-    // 마운트 시 메인 목록을 불러옵니다. (정렬 옵션 제거됨)
-    fetchMoreFestivals(); // ⚠️ currentSort 대신 직접 호출
-  }, [fetchMoreFestivals]); 
+  useEffect(() => {
+    fetchMoreFestivals();
+  }, [fetchMoreFestivals]);
 
+  const myTimetableDisplayData = myTimetables;
+  const recommendData = recommendedFestivals;
+  const displayFestivalData = morefestival;
 
-  const myTimetableDisplayData = myTimetables; 
-  const recommendData = recommendedFestivals; 
-  const displayFestivalData = morefestival; 
+  return (
+    <>
+      <Alarm />
+      <div className={timetablestyles.mainContentWrapper}>
 
-  return (
-    <>
-        <Alarm />
-      
-      <div className={timetablestyles.mainContentWrapper}>
-        
-        {/* --- 1. 나의 타임테이블 섹션 --- */}
-        {(isMyListLoading || myListError || myTimetableDisplayData.length > 0) && (
-          <section className={timetablestyles.mytimetableSection}>
-            <SectionHeader
-              subtitle="공연 관람이 며칠 안 남았다면?"
-              mainTitleLines={["나의\u00A0", "타임테이블"]}
-              boldParts={[1]}
-            />
-            {isMyListLoading && <p className={timetablestyles.loadingText}>나의 타임테이블을 불러오는 중...</p>}
-            {myListError && <p className={timetablestyles.errorText}>{myListError}</p>}
+        {(isMyListLoading || myListError || myTimetableDisplayData.length > 0) && (
+          <section className={timetablestyles.mytimetableSection}>
 
-            {!isMyListLoading && !myListError && myTimetableDisplayData.length > 0 && (
-              <ul className={timetablestyles.timetableList}>
-                {myTimetableDisplayData.map((item) => (
-                  <FestivalListItem
-                    key={item.id}
-                    itemData={item}
-                    onClick={() => handleMyTimetableClick(item.id)}
-                    onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
-                  />
-                ))}
-              </ul>
-            )}
-          
-            {!isMyListLoading && !myListError && myTimetableDisplayData.length === 0 && (
-              <p className={timetablestyles.noDataText}>나만의 타임테이블을 만들어 보세요!</p>
-            )}
-          </section>
-        )}
-        
-        {/* --- 2. 나의 관심 페스티벌의 타임테이블 확인하기 --- */}
-        {(isFavoritesLoading || favoritesError || recommendData.length > 0) && (
-          <section className={timetablestyles.check}>
-            <SectionHeader
-              subtitle="나의 관심 페스티벌의"
-              mainTitleLines={["타임테이블\u00A0", "확인하기"]}
-              boldParts={[0]}
-            />
+            <SectionHeader
+              subtitle="공연 관람이 며칠 안 남았다면?"
+              mainTitleLines={["나의 ", "타임테이블"]}
+              boldParts={[1]}
+            />
 
-            {isFavoritesLoading && <p className={timetablestyles.loadingText}>관심 목록을 불러오는 중...</p>}
-            {favoritesError && <p className={timetablestyles.errorText}>{favoritesError}</p>}
-          
-            {!isFavoritesLoading && !favoritesError && recommendData.length > 0 && (
-              <div className={timetablestyles.recommendListWrapper}>
-                {recommendData.map((item) => (
-                  <RecommendCard
-                    key={item.id}
-                    itemData={item} 
-                    onCustomizeClick={() => handleCustomizeClick(item.id)}
-                  />
-                ))}
-              </div>
-            )}
-          
-            {!isFavoritesLoading && !favoritesError && recommendData.length === 0 && (
-              <p className={timetablestyles.noDataText}>관심 페스티벌 데이터가 없습니다.</p>
-            )}
-          </section>
-        )}
-        {/* --- */}
+            {isMyListLoading && (
+              <p className={timetablestyles.loadingText}>
+                나의 타임테이블을 불러오는 중...
+              </p>
+            )}
 
-        {/* --- 3. 더 많은 페스티벌 섹션 --- */}
-        <section className={timetablestyles.moretimetableSection}>
-          <SectionHeader
-            subtitle="더 많은 페스티벌의"
-            mainTitleLines={["타임테이블", "을\u00A0확인해\u00A0보세요!"]}
-            boldParts={[0]}
-          />
-          
-          {/* ⚠️ 정렬 옵션 UI 제거 ⚠️ */}
-         
-          {isLoading && <p className={timetablestyles.loadingText}>페스티벌 목록을 불러오는 중...</p>}
-          {error && <p className={timetablestyles.errorText}>{error}</p>}
-          
-          {!isLoading && !error && displayFestivalData.length > 0 && (
-            <ul className={timetablestyles.timetableList}>
-              {displayFestivalData.map((item) => (
-                <FestivalListItem
-                  key={item.id}
-                  itemData={item}
-                  onClick={() => handleCustomizeClick(item.id)}
-                  onLikeChangeSuccess={(id, newState) => handleLikeChangeSuccess(id, newState)} 
-                />
-              ))}
-            </ul>
-          )}
-          
-          {!isLoading && !error && displayFestivalData.length === 0 && (
-            <p className={timetablestyles.noDataText}>해당 조건에 맞는 페스티벌이 없습니다.</p>
-          )}
+            {myListError && (
+              <p className={timetablestyles.errorText}>{myListError}</p>
+            )}
 
-        </section>
-      </div>
-    </>
-  );
+            {!isMyListLoading &&
+              !myListError &&
+              myTimetableDisplayData.length > 0 && (
+                <ul className={timetablestyles.timetableList}>
+                  {myTimetableDisplayData.map((item) => (
+                    <FestivalListItem
+                      key={item.id}
+                      itemData={item}
+                      onClick={() => handleMyTimetableClick(item.id)}
+                      onLikeChangeSuccess={(id, newState) =>
+                        handleLikeChangeSuccess(id, newState)
+                      }
+                    />
+                  ))}
+                </ul>
+              )}
+
+            {!isMyListLoading &&
+              !myListError &&
+              myTimetableDisplayData.length === 0 && (
+                <p className={timetablestyles.noDataText}>
+                  나만의 타임테이블을 만들어 보세요!
+                </p>
+              )}
+          </section>
+        )}
+
+        {/* ⭐️ 관심 목록 섹션은 recommendData를 사용하므로 변경 없음 ⭐️ */}
+        {(isFavoritesLoading || favoritesError || recommendData.length > 0) && (
+          <section className={timetablestyles.check}>
+
+            <SectionHeader
+              subtitle="나의 관심 페스티벌의"
+              mainTitleLines={["타임테이블 ", "확인하기"]}
+              boldParts={[0]}
+            />
+
+            {isFavoritesLoading && (
+              <p className={timetablestyles.loadingText}>
+                관심 목록을 불러오는 중...
+              </p>
+            )}
+
+            {favoritesError && (
+              <p className={timetablestyles.errorText}>{favoritesError}</p>
+            )}
+
+            {!isFavoritesLoading &&
+              !favoritesError &&
+              recommendData.length > 0 && (
+                <div className={timetablestyles.recommendListWrapper}>
+                  {recommendData.map((item) => (
+                    <RecommendCard
+                      key={item.id}
+                      itemData={item}
+                      onCustomizeClick={() => handleCustomizeClick(item.id)}
+                    />
+                  ))}
+                </div>
+              )}
+
+            {!isFavoritesLoading &&
+              !favoritesError &&
+              recommendData.length === 0 && (
+                <p className={timetablestyles.noDataText}>
+                  관심 페스티벌 데이터가 없습니다.
+                </p>
+              )}
+          </section>
+        )}
+
+        <section className={timetablestyles.moretimetableSection}>
+
+          <SectionHeader
+            subtitle="더 많은 페스티벌의"
+            mainTitleLines={["타임테이블", "을 확인해 보세요!"]}
+            boldParts={[0]}
+          />
+
+          {isLoading && (
+            <p className={timetablestyles.loadingText}>
+              페스티벌 목록을 불러오는 중...
+            </p>
+          )}
+
+          {error && <p className={timetablestyles.errorText}>{error}</p>}
+
+          {!isLoading && !error && displayFestivalData.length > 0 && (
+            <ul className={timetablestyles.timetableList}>
+              {displayFestivalData.map((item) => (
+                <FestivalListItem
+                  key={item.id}
+                  itemData={item}
+                  onClick={() => handleCustomizeClick(item.id)}
+                  onLikeChangeSuccess={(id, newState) =>
+                    handleLikeChangeSuccess(id, newState)
+                  }
+                />
+              ))}
+            </ul>
+          )}
+
+          {!isLoading && !error && displayFestivalData.length === 0 && (
+            <p className={timetablestyles.noDataText}>
+              해당 조건에 맞는 페스티벌이 없습니다.
+            </p>
+          )}
+        </section>
+      </div>
+    </>
+  );
 };
 
 export default TimetableMainPage;

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -53,19 +53,28 @@ const TimetableMainPage = () => {
   useEffect(() => {
     // Mock Data 초기화
     const mockData1: FestivalItem[] = [
-      { id: 1, title: "그랜드 민트 페스티벌 2025", likes: 12, location: "일산 킨텍스", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/img1.png" },
+       { id: 1, title: "그랜드 민트 페스티벌 2025", likes: 12, location: "일산 킨텍스", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/img1.png" },
       { id: 2, title: "COUNTDOWN FANTASY 2025-2026", likes: 10, location: "일산 킨텍스", date: "2025.12.30 - 2025.12.31", thumbnailUrl: "/path/to/img2.png" },
+    
     ];
     setTimetableList(mockData1);
 
     const mockData2: RecommendItem[] = [
-      { id: 3, title: "COUNTDOWN FANTASY 2025-2026", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster1.png" },
+       { id: 3, title: "COUNTDOWN FANTASY 2025-2026", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster1.png" },
       { id: 4, title: "DMZ 피스트레인 뮤직 페스티벌 2025", date: "2025.10.18 - 2025.10.19", thumbnailUrl: "/path/to/poster2.png" },
-    ];
+      { id: 5, title: "2025 부산 락 페스티벌", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster3.png" },
+      { id: 6, title: "서울 재즈 페스티벌 2025", date: "2025.05.28 - 2025.05.30", thumbnailUrl: "/path/to/poster4.png" },
+     ];
     setRecommendedFestivals(mockData2);
     
     const mockData3: FestivalItem[] = [
-        { id: 7, title: "더 많은 페스티벌 1", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img7.png" },
+        { id: 7, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
+          { id: 8, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
+          { id: 9, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
+          { id: 10, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
+          { id: 11, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
+          { id: 12, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
+        
     ];
     setMorefestival(mockData3);
   }, []);

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,5 +1,3 @@
-// src/pages/timetable/TimetableMainPage.tsx
-
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import timetablestyles from "../../css/pages/timetable/timetablemain.module.css";
@@ -7,28 +5,46 @@ import FestivalListItem from "../../components/timetable/FestivalListItem";
 import SectionHeader from "../../components/SectionHeader";
 import RecommendCard from "../../components/timetable/RecommendCard";
 import Alarm from "../../components/Alarm";
-import api from "../../api/api"; // ⭐️ 사용자가 import 한 api 객체 ⭐️
+import api from "../../api/api"; 
 
-// ⭐️ API 응답 타입 정의 (더 많은 페스티벌 API의 응답 구조) ⭐️
+// ⭐️ API 응답 타입 정의 (KopisFestivalItem: JSON 요청 형식과 매핑) ⭐️
 // 실제 API 응답 구조를 기반으로 필드명을 사용합니다.
-interface KopisFestivalItem {
+export interface KopisFestivalItem {
   id: number; // FestivalItem의 id와 매핑
-  mt20id: string; 
+  mt20id: string; // Kopis 공연 ID
   prfnm: string; // FestivalItem의 title과 매핑 (공연명)
-  prfpdfrom: string; // 공연 시작일
-  prfpdto: string; // 공연 종료일
+  prfpdfrom: string; // 공연 시작일 (ex. "2025-12-04")
+  prfpdto: string; // 공연 종료일 (ex. "2025-12-04")
   fcltynm: string; // FestivalItem의 location과 매핑 (시설명)
+  prfruntime: string; // 공연 런타임
+  prfage: string; // 관람 연령
+  pcseguidance: string; // 가격 정보
   poster: string; // FestivalItem의 thumbnailUrl과 매핑 (포스터 URL)
-  // ... 기타 필드 (생략)
+  prfstate: string; // 공연 상태
+  dtguidance: string; // 시간 안내
+  tkstdate: string; // 티켓 오픈일
+  // time 객체는 hour, minute 등을 포함한다고 가정
+  tksttime: { hour: number; minute: number; second: number; nano: number; }; 
+  typeofcon: number;
+  newstate: boolean;
+  locationUrl: string;
+  styurls: { relatenm: string; relateurl: string; }[];
+  relates: { relatenm: string; relateurl: string; }[];
+  days: { date: string; open: { hour: number; minute: number; second: number; nano: number; }; close: { hour: number; minute: number; second: number; nano: number; }; }[];
+  // slot의 start/end도 time 객체를 포함한다고 가정
+  slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: { hour: number; minute: number; second: number; nano: number; }; end: { hour: number; minute: number; second: number; nano: number; }; minutes: number; img: string; note: string; }[];
+  fesLinks: { relatenm: string; relateurl: string; }[];
+  artistPics: { date: string; relatenm: string; url: string; }[];
 }
 
-// ⭐️ 수정: 인터페이스를 export 합니다. ⭐️
+
+// ⭐️ 수정: 인터페이스를 export 합니다. (UI 컴포넌트에 필요한 필드) ⭐️
 export interface FestivalItem {
   id: number;
   title: string;
-  likes: number; // API에 없는 경우 0으로 임시 설정 필요
+  likes: number; // API에 없는 경우 0으로 임시 설정
   location: string;
-  date: string;
+  date: string; // "YYYY.MM.DD - YYYY.MM.DD" 형식
   thumbnailUrl: string;
 }
 
@@ -61,9 +77,19 @@ const TimetableMainPage = () => {
   const [error, setError] = useState<string | null>(null);
 
 
-  // 1. 커스텀 '생성' 경로 이동 함수
-  const handleCustomizeClick = (festivalId: number) => { 
-    navigate(`/main/timetable/customize/${festivalId}`);
+  // 1. 커스텀 '생성' 경로 이동 함수 (FestivalItem 또는 RecommendItem 객체를 인수로 받도록 수정)
+  const handleCustomizeClick = (item: FestivalItem | RecommendItem) => { 
+    // FestivalItem과 RecommendItem의 공통 필드만 넘겨도 무방합니다.
+    navigate(`/main/timetable/customize/${item.id}`, {
+        state: { 
+            id: item.id,
+            title: item.title,
+            // FestivalItem에만 'location'이 있으므로 타입 캐스팅 및 기본값 처리
+            location: (item as FestivalItem).location || '정보 없음', 
+            date: item.date,
+            thumbnailUrl: item.thumbnailUrl
+        }
+    });
   };
 
   // 2. 나의 타임테이블 '수정' 경로 이동 함수
@@ -77,19 +103,21 @@ const TimetableMainPage = () => {
     setError(null);
     
     try {
-      // ⭐️ api 객체를 사용하여 GET 요청을 보냅니다. ⭐️
-      // API 주소: /kopis/performances/festivals (v1은 제외)
+      // api 객체를 사용하여 GET 요청을 보냅니다.
       const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
       
+      // KopisFestivalItem[] 타입으로 가정합니다.
       const apiData: KopisFestivalItem[] = response.data; 
       
-      // ⭐️ API 응답을 FestivalItem 타입에 맞게 변환 (매핑) ⭐️
+      // ⭐️ API 응답을 FestivalItem 타입에 맞게 변환 (매핑 로직) ⭐️
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.id,
           title: item.prfnm, 
-          likes: 0, // API에 '좋아요' 데이터가 없으므로 0으로 임시 처리
+          // Kopis API에 좋아요 데이터가 직접 없으므로 0으로 임시 처리
+          likes: 0, 
           location: item.fcltynm, 
-          date: `${item.prfpdfrom} - ${item.prfpdto}`, 
+          // 시작일과 종료일을 묶어 date 필드 생성
+          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
           thumbnailUrl: item.poster, 
       }));
 
@@ -97,7 +125,6 @@ const TimetableMainPage = () => {
       
     } catch (err) {
       console.error("페스티벌 목록을 불러오는 중 오류 발생:", err);
-      // 에러 객체에 따라 메시지를 다르게 처리할 수 있습니다.
       setError("데이터를 불러오는 데 실패했습니다. 다시 시도해 주세요.");
       setMorefestival([]);
     } finally {
@@ -123,8 +150,7 @@ const TimetableMainPage = () => {
      ];
     setRecommendedFestivals(mockData2);
     
-    // ⭐️ 3. 더 많은 페스티벌 Mock Data 제거 (API 호출로 대체) ⭐️
-    // setMorefestival(mockData3);
+    // 3. 더 많은 페스티벌 Mock Data 제거 (API 호출로 대체)
   }, []);
   
   // ⭐️ currentSort 상태가 변경되거나 컴포넌트 마운트 시 API 호출 ⭐️
@@ -153,7 +179,8 @@ const TimetableMainPage = () => {
               <FestivalListItem
                 key={item.id}
                 itemData={item}
-                onClick={() => handleMyTimetableClick(item.id)}
+                // 나의 타임테이블은 ID만 넘겨도 무방
+                onClick={() => handleMyTimetableClick(item.id)} 
               />
             ))}
           </ul>
@@ -171,7 +198,8 @@ const TimetableMainPage = () => {
               <RecommendCard
                 key={item.id}
                 itemData={item}
-                onCustomizeClick={() => handleCustomizeClick(item.id)}
+                // ⭐️ 수정: item 객체 전체를 인수로 전달 ⭐️
+                onCustomizeClick={() => handleCustomizeClick(item)} 
               />
             ))}
           </div>
@@ -210,7 +238,8 @@ const TimetableMainPage = () => {
                 <FestivalListItem
                   key={item.id}
                   itemData={item}
-                  onClick={() => handleCustomizeClick(item.id)}
+                  // ⭐️ 수정: item 객체 전체를 인수로 전달 ⭐️
+                  onClick={() => handleCustomizeClick(item)}
                 />
               ))}
             </ul>

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,6 +1,6 @@
-// src/pages/timetable/TimetableMainPage.tsx
+// src/pages/timetable/TimetableMainPage.tsx (최종 수정: 좋아요 목록 섹션 제거 및 데이터 흐름 변경)
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import timetablestyles from "../../css/pages/timetable/timetablemain.module.css";
 import FestivalListItem from "../../components/timetable/FestivalListItem";
@@ -9,50 +9,37 @@ import RecommendCard from "../../components/timetable/RecommendCard";
 import Alarm from "../../components/Alarm";
 import api from "../../api/api"; 
 
-// ⭐️ API 응답 타입 정의 (KopisFestivalItem: /kopis 및 /festivals/custom 모두 사용) ⭐️
+// ⭐️ [가정] API 응답 타입 ⭐️
 export interface KopisFestivalItem {
-  id: number; // FestivalItem의 id와 매핑
-  mt20id: string; // Kopis 공연 ID
-  prfnm: string; // FestivalItem의 title과 매핑 (공연명)
-  prfpdfrom: string; // 공연 시작일 (ex. "2025-12-04")
-  prfpdto: string; // 공연 종료일 (ex. "2025-12-04")
-  fcltynm: string; // FestivalItem의 location과 매핑 (시설명)
-  prfruntime: string; // 공연 런타임
-  prfage: string; // 관람 연령
-  pcseguidance: string; // 가격 정보
-  poster: string; // FestivalItem의 thumbnailUrl과 매핑 (포스터 URL)
-  prfstate: string; // 공연 상태
-  dtguidance: string; // 시간 안내
-  tkstdate: string; // 티켓 오픈일
-  tksttime: { hour: number; minute: number; second: number; nano: number; };
-  typeofcon: number;
-  newstate: boolean;
-  locationUrl: string;
-  styurls: { relatenm: string; relateurl: string; }[];
-  relates: { relatenm: string; relateurl: string; }[];
-  days: { date: string; open: { hour: number; minute: number; second: number; nano: number; }; close: { hour: number; minute: number; second: number; nano: number; }; }[];
-  slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: { hour: number; minute: number; second: number; nano: number; }; end: { hour: number; minute: number; second: number; nano: number; }; minutes: number; img: string; note: string; }[];
-  fesLinks: { relatenm: string; url: string; }[];
-  artistPics: { date: string; relatenm: string; url: string; }[];
+  id: number;
+  mt20id: string; 
+  prfnm: string; 
+  prfpdfrom: string; 
+  prfpdto: string; 
+  fcltynm: string; 
+  poster: string; 
+  
+  performanceId?: number; 
+  title?: string; 
+  posterUrl?: string; 
+
+  isLiked?: boolean; 
+  likeCount?: number; 
 }
 
-
-// ⭐️ UI 컴포넌트에 필요한 최종 FestivalItem 타입 (기존 유지) ⭐️
+// ⭐️ [UI 타입] 최종 FestivalItem 타입 ⭐️
 export interface FestivalItem {
   id: number;
   title: string;
-  likes: number; // API에 없는 경우 0으로 임시 설정
+  likeCount: number; 
+  isLiked: boolean; 
   location: string;
-  date: string; // "YYYY.MM.DD - YYYY.MM.DD" 형식
+  date: string; 
   thumbnailUrl: string;
 }
 
-export interface RecommendItem {
-  id: number;
-  title: string;
-  date: string;
-  thumbnailUrl: string;
-}
+// ⭐️ [RecommendItem 타입] FestivalItem과 동일한 구조를 가집니다. ⭐️
+export interface RecommendItem extends FestivalItem {}
 
 const sortOptions = [
   { label: "최신 등록순", key: "latest" },
@@ -63,64 +50,92 @@ const sortOptions = [
 const TimetableMainPage = () => {
   const navigate = useNavigate();
   
-  // ⭐️ [수정] 나의 타임테이블 목록 상태를 API 데이터로 변경 ⭐️
   const [myTimetables, setMyTimetables] = useState<FestivalItem[]>([]);
-  const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]);
+  // myFavorites 상태는 데이터를 가져오는 역할만 합니다.
+  const [myFavorites, setMyFavorites] = useState<FestivalItem[]>([]); 
   
-  // ⭐️ API 데이터 상태 ⭐️
+  // ⭐️ recommendedFestivals는 myFavorites 데이터를 받아 RecommendCard에 표시합니다. ⭐️
+  const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]); 
+  
   const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
   const [currentSort, setCurrentSort] = useState(sortOptions[0].key); 
   
-  // ⭐️ API 호출 상태 ⭐️
   const [isLoading, setIsLoading] = useState(false);
-  // ⭐️ [추가] 나의 타임테이블 전용 로딩/에러 상태 ⭐️
   const [isMyListLoading, setIsMyListLoading] = useState(true); 
+  const [isFavoritesLoading, setIsFavoritesLoading] = useState(false); // 로딩 상태는 유지
+  
   const [error, setError] = useState<string | null>(null);
   const [myListError, setMyListError] = useState<string | null>(null); 
+  const [favoritesError, setFavoritesError] = useState<string | null>(null);
 
-
-  // 1. 커스텀 '생성' 경로 이동 함수
+  
   const handleCustomizeClick = (festivalId: number) => { 
     navigate(`/main/timetable/customize/${festivalId}`);
   };
 
-  // 2. 나의 타임테이블 '수정' 경로 이동 함수
   const handleMyTimetableClick = (festivalId: number) => { 
     navigate(`/main/timetable/my/${festivalId}`);
   };
+
+
+  // ⭐️ 나의 관심 페스티벌 목록 조회 (좋아요 목록) ⭐️
+  const fetchMyFavorites = useCallback(async () => {
+    setIsFavoritesLoading(true);
+    setFavoritesError(null);
+    const API_ENDPOINT = '/likes/my/festivals'; 
+    
+    try {
+      const response = await api.get(API_ENDPOINT); 
+      const apiData: any[] = response.data.data || response.data; 
+      
+      const transformedData: FestivalItem[] = apiData.map(item => ({
+          id: item.performanceId,
+          title: item.title,
+          likeCount: 0, 
+          isLiked: true, 
+          location: item.fcltynm,
+          date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
+          thumbnailUrl: item.posterUrl,
+      }));
+
+      // ⭐️ 핵심 변경: myFavorites와 recommendedFestivals를 모두 업데이트 ⭐️
+      setMyFavorites(transformedData); 
+      setRecommendedFestivals(transformedData as RecommendItem[]); // 데이터를 RecommendCard 섹션으로 전달
+      
+    } catch (err) {
+      console.error(`❌ 나의 관심 페스티벌 목록 로드 중 오류 발생:`, err);
+      setFavoritesError("관심 목록을 불러오는 데 실패했습니다.");
+      setMyFavorites([]);
+      setRecommendedFestivals([]);
+    } finally {
+      setIsFavoritesLoading(false);
+    }
+  }, []); 
+
   
-  // ⭐️ ⭐️ [새로운 API 호출] 나의 타임테이블 목록 조회 함수 ⭐️ ⭐️
-  // API 주소: /festivals/custom
   const fetchMyTimetables = async () => {
     setIsMyListLoading(true);
     setMyListError(null);
-    
+    // ... (나의 타임테이블 로직 유지) ...
     const API_ENDPOINT = '/festivals/custom'; 
     
     try {
-      // ⭐️ GET /festivals/custom 호출 (인증 헤더 필요) ⭐️
       const response = await api.get(API_ENDPOINT); 
-      
-      // API 응답 데이터가 KopisFestivalItem[] 배열 형태라고 가정합니다.
       const apiData: KopisFestivalItem[] = response.data.data || response.data; 
       
-      // ⭐️ API 응답을 FestivalItem 타입에 맞게 변환 (매핑 로직) ⭐️
       const transformedData: FestivalItem[] = apiData.map(item => ({
-          id: item.id, // FestivalListItem의 key와 id로 사용
-          title: item.prfnm, // 공연명 (title)
-          likes: 0, // 좋아요 데이터가 없다면 임시 값 사용
-          location: item.fcltynm, // 시설명 (location)
-          // prfpdfrom(시작일)과 prfpdto(종료일)을 조합하여 date 형식으로 만듦
+          id: item.id,
+          title: item.prfnm,
+          likeCount: item.likeCount || 0, 
+          isLiked: item.isLiked || false, 
+          location: item.fcltynm, 
           date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
-          thumbnailUrl: item.poster, // 포스터 URL (thumbnailUrl)
+          thumbnailUrl: item.poster, 
       }));
 
       setMyTimetables(transformedData);
-      console.log(`✅ [GET ${API_ENDPOINT}] 나의 타임테이블 목록 응답:`, response.data);
-      
     } catch (err) {
       console.error(`❌ 나의 타임테이블 목록 (${API_ENDPOINT}) 로드 중 오류 발생:`, err);
-      // 로그인 문제 등 4xx 에러 처리를 위해 에러 메시지 업데이트
       setMyListError("나의 타임테이블을 불러오는 데 실패했습니다. (로그인 상태 확인)");
       setMyTimetables([]);
     } finally {
@@ -129,26 +144,21 @@ const TimetableMainPage = () => {
   };
 
 
-  // ⭐️ API 호출 함수: 더 많은 페스티벌 목록 조회 (기존 유지) ⭐️
-  const fetchMoreFestivals = async (sortKey: string) => {
+  // 더 많은 페스티벌 목록 조회
+  const fetchMoreFestivals = useCallback(async (sortKey: string) => {
     setIsLoading(true);
     setError(null);
     
     try {
-      // api 객체를 사용하여 GET 요청을 보냅니다.
       const response = await api.get(`/kopis/performances/festivals?sort=${sortKey}`); 
-      
-      // KopisFestivalItem[] 타입으로 가정합니다.
       const apiData: KopisFestivalItem[] = response.data; 
       
-      // ⭐️ API 응답을 FestivalItem 타입에 맞게 변환 (매핑 로직) ⭐️
       const transformedData: FestivalItem[] = apiData.map(item => ({
           id: item.id,
           title: item.prfnm, 
-          // Kopis API에 좋아요 데이터가 직접 없으므로 0으로 임시 처리
-          likes: 0, 
+          likeCount: item.likeCount || 0, 
+          isLiked: item.isLiked || false, 
           location: item.fcltynm, 
-          // 시작일과 종료일을 묶어 date 필드 생성
           date: `${item.prfpdfrom.replace(/-/g, '.')} - ${item.prfpdto.replace(/-/g, '.')}`, 
           thumbnailUrl: item.poster, 
       }));
@@ -162,32 +172,31 @@ const TimetableMainPage = () => {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []); 
+
+
+  // 좋아요 상태 변경 시 목록 전체 새로고침 콜백
+  const handleLikeChangeSuccess = useCallback(() => {
+    // 좋아요 상태가 변경되면, 모든 목록을 새로고침하여 isLiked 상태를 동기화합니다.
+    fetchMyFavorites(); // 이 호출이 recommendedFestivals를 새로고침합니다.
+    fetchMoreFestivals(currentSort); 
+  }, [fetchMyFavorites, fetchMoreFestivals, currentSort]);
 
 
   useEffect(() => {
-    // ⭐️ ⭐️ [수정] 1. 나의 타임테이블 API 호출로 대체 ⭐️ ⭐️
     fetchMyTimetables();
+    // ⭐️ 좋아요 목록을 가져와 recommendedFestivals에 설정 ⭐️
+    fetchMyFavorites(); 
     
-    // 2. 추천 페스티벌 (Mock Data 유지)
-    const mockData2: RecommendItem[] = [
-       { id: 3, title: "COUNTDOWN FANTASY 2025-2026", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster1.png" },
-      { id: 4, title: "DMZ 피스트레인 뮤직 페스티벌 2025", date: "2025.10.18 - 2025.10.19", thumbnailUrl: "/path/to/poster2.png" },
-      { id: 5, title: "2025 부산 락 페스티벌", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster3.png" },
-      { id: 6, title: "서울 재즈 페스티벌 2025", date: "2025.05.28 - 2025.05.30", thumbnailUrl: "/path/to/poster4.png" },
-     ];
-    setRecommendedFestivals(mockData2);
-    
-  }, []);
+  }, [fetchMyFavorites]); 
   
-  // ⭐️ currentSort 상태가 변경되거나 컴포넌트 마운트 시 API 호출 (기존 유지) ⭐️
   useEffect(() => {
     fetchMoreFestivals(currentSort);
-  }, [currentSort]); 
+  }, [currentSort, fetchMoreFestivals]); 
 
-  // ⭐️ [수정] myTimetables 상태 사용 ⭐️
+
   const myTimetableDisplayData = myTimetables; 
-  const recommendData = recommendedFestivals;
+  const recommendData = recommendedFestivals; // 좋아요 목록 데이터
   const displayFestivalData = morefestival; 
 
   return (
@@ -195,14 +204,13 @@ const TimetableMainPage = () => {
        <Alarm></Alarm>
       <div className={timetablestyles.mainContentWrapper}>
         
+        {/* --- 1. 나의 타임테이블 섹션 (유지) --- */}
         <section className={timetablestyles.mytimetableSection}>
           <SectionHeader
             subtitle="공연 관람이 며칠 안 남았다면?"
             mainTitleLines={["나의\u00A0", "타임테이블"]}
             boldParts={[1]}
           />
-
-          {/* ⭐️ [수정] 나의 타임테이블 로딩/에러/데이터 표시 로직 ⭐️ */}
           {isMyListLoading && <p className={timetablestyles.loadingText}>나의 타임테이블을 불러오는 중...</p>}
           {myListError && <p className={timetablestyles.errorText}>{myListError}</p>}
 
@@ -213,6 +221,7 @@ const TimetableMainPage = () => {
                   key={item.id}
                   itemData={item}
                   onClick={() => handleMyTimetableClick(item.id)}
+                  onLikeChangeSuccess={handleLikeChangeSuccess} 
                 />
               ))}
             </ul>
@@ -221,10 +230,13 @@ const TimetableMainPage = () => {
           {!isMyListLoading && !myListError && myTimetableDisplayData.length === 0 && (
             <p className={timetablestyles.noDataText}>나만의 타임테이블을 만들어 보세요!</p>
           )}
-
         </section>
 
-        {/* --- 추천 페스티벌 섹션은 변경 없음 --- */}
+        
+        {/* ❌ 2. 나의 관심 페스티벌 섹션 (제거 완료) ❌ */}
+
+        
+        {/* --- 3. 나의 관심 페스티벌의 타임테이블 확인하기 (RecommendCard로 좋아요 목록 표시) --- */}
         <section className={timetablestyles.check}>
           <SectionHeader
             subtitle="나의 관심 페스티벌의"
@@ -232,19 +244,29 @@ const TimetableMainPage = () => {
             boldParts={[0]}
           />
 
-          <div className={timetablestyles.recommendListWrapper}>
-            {recommendData.map((item) => (
-              <RecommendCard
-                key={item.id}
-                itemData={item}
-                onCustomizeClick={() => handleCustomizeClick(item.id)}
-              />
-            ))}
-          </div>
+          {isFavoritesLoading && <p className={timetablestyles.loadingText}>관심 목록을 불러오는 중...</p>}
+          {favoritesError && <p className={timetablestyles.errorText}>{favoritesError}</p>}
+          
+          {/* 좋아요 목록이 로드되면 RecommendCard로 표시 */}
+          {!isFavoritesLoading && !favoritesError && recommendData.length > 0 && (
+            <div className={timetablestyles.recommendListWrapper}>
+              {recommendData.map((item) => (
+                <RecommendCard
+                  key={item.id}
+                  itemData={item} // 좋아요 목록 데이터
+                  onCustomizeClick={() => handleCustomizeClick(item.id)}
+                />
+              ))}
+            </div>
+          )}
+          
+          {!isFavoritesLoading && !favoritesError && recommendData.length === 0 && (
+            <p className={timetablestyles.noDataText}>관심 페스티벌 데이터가 없습니다.</p>
+          )}
         </section>
         {/* --- */}
 
-        {/* --- 더 많은 페스티벌 섹션은 변경 없음 --- */}
+        {/* --- 4. 더 많은 페스티벌 섹션 (유지) --- */}
         <section className={timetablestyles.moretimetableSection}>
           <SectionHeader
             subtitle="더 많은 페스티벌의"
@@ -266,11 +288,9 @@ const TimetableMainPage = () => {
             ))}
           </div>
           
-          {/* ⭐️ 로딩 및 에러 상태 표시 ⭐️ */}
           {isLoading && <p className={timetablestyles.loadingText}>페스티벌 목록을 불러오는 중...</p>}
           {error && <p className={timetablestyles.errorText}>{error}</p>}
           
-          {/* ⭐️ 데이터가 로드되었을 때만 목록 표시 ⭐️ */}
           {!isLoading && !error && displayFestivalData.length > 0 && (
             <ul className={timetablestyles.timetableList}>
               {displayFestivalData.map((item) => (
@@ -278,6 +298,7 @@ const TimetableMainPage = () => {
                   key={item.id}
                   itemData={item}
                   onClick={() => handleCustomizeClick(item.id)}
+                  onLikeChangeSuccess={handleLikeChangeSuccess} 
                 />
               ))}
             </ul>

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -6,6 +6,7 @@ import timetablestyles from "../../css/pages/timetable/timetablemain.module.css"
 import FestivalListItem from "../../components/timetable/FestivalListItem";
 import SectionHeader from "../../components/SectionHeader";
 import RecommendCard from "../../components/timetable/RecommendCard";
+import Alarm from "../../components/Alarm";
 
 // ⭐️ 수정: 인터페이스를 export 합니다. ⭐️
 export interface FestivalItem {
@@ -85,7 +86,9 @@ const TimetableMainPage = () => {
 
   return (
     <>
+       <Alarm></Alarm>
       <div className={timetablestyles.mainContentWrapper}>
+        
         <section className={timetablestyles.mytimetableSection}>
           <SectionHeader
             subtitle="공연 관람이 며칠 안 남았다면?"

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -1,12 +1,14 @@
 // src/pages/timetable/TimetableMainPage.tsx
 
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import timetablestyles from "../../css/pages/timetable/timetablemain.module.css";
 import FestivalListItem from "../../components/timetable/FestivalListItem";
 import SectionHeader from "../../components/SectionHeader";
 import RecommendCard from "../../components/timetable/RecommendCard";
 
-interface FestivalItem {
+// ⭐️ 수정: 인터페이스를 export 합니다. ⭐️
+export interface FestivalItem {
   id: number;
   title: string;
   likes: number;
@@ -15,7 +17,7 @@ interface FestivalItem {
   thumbnailUrl: string;
 }
 
-interface RecommendItem {
+export interface RecommendItem {
   id: number;
   title: string;
   date: string;
@@ -29,36 +31,27 @@ const sortOptions = [
 ];
 
 const TimetableMainPage = () => {
+  const navigate = useNavigate();
+  // Mock 데이터
   const [timetableList, setTimetableList] = useState<FestivalItem[]>([]);
   const [recommendedFestivals, setRecommendedFestivals] = useState<RecommendItem[]>([]);
   const [morefestival, setMorefestival] = useState<FestivalItem[]>([]);
 
   const [currentSort, setCurrentSort] = useState(sortOptions[0].key); 
 
+  // 1. 커스텀 '생성' 경로 이동 함수
   const handleCustomizeClick = (festivalId: number) => { 
-    console.log(`Festival ID ${festivalId}의 커스텀 페이지로 이동 요청.`);
-    alert(`[라우팅]: 페스티벌 ID ${festivalId}의 커스텀 페이지로 이동합니다.`);
+    navigate(`/main/timetable/customize/${festivalId}`);
   };
 
-  useEffect(() => {
-    async function fetchSortedFestivals() {
-      if (morefestival.length === 0) {
-        const mockData3: FestivalItem[] = [
-          { id: 7, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 8, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 9, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 10, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 11, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-          { id: 12, title: "페스티벌 이름", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img1.png" },
-        ];
-        setMorefestival(mockData3);
-      }
-    }
-    
-    fetchSortedFestivals();
-  }, [currentSort, morefestival.length]); 
+  // 2. 나의 타임테이블 '수정' 경로 이동 함수
+  const handleMyTimetableClick = (festivalId: number) => { 
+    navigate(`/main/timetable/my/${festivalId}`);
+  };
+
 
   useEffect(() => {
+    // Mock Data 초기화
     const mockData1: FestivalItem[] = [
       { id: 1, title: "그랜드 민트 페스티벌 2025", likes: 12, location: "일산 킨텍스", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/img1.png" },
       { id: 2, title: "COUNTDOWN FANTASY 2025-2026", likes: 10, location: "일산 킨텍스", date: "2025.12.30 - 2025.12.31", thumbnailUrl: "/path/to/img2.png" },
@@ -68,10 +61,13 @@ const TimetableMainPage = () => {
     const mockData2: RecommendItem[] = [
       { id: 3, title: "COUNTDOWN FANTASY 2025-2026", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster1.png" },
       { id: 4, title: "DMZ 피스트레인 뮤직 페스티벌 2025", date: "2025.10.18 - 2025.10.19", thumbnailUrl: "/path/to/poster2.png" },
-      { id: 5, title: "2025 부산 락 페스티벌", date: "2025.12.20 - 2025.12.21", thumbnailUrl: "/path/to/poster3.png" },
-      { id: 6, title: "서울 재즈 페스티벌 2025", date: "2025.05.28 - 2025.05.30", thumbnailUrl: "/path/to/poster4.png" },
     ];
     setRecommendedFestivals(mockData2);
+    
+    const mockData3: FestivalItem[] = [
+        { id: 7, title: "더 많은 페스티벌 1", likes: 999, location: "페스티벌 위치", date: "2025.12.20 - 12.21", thumbnailUrl: "/path/to/img7.png" },
+    ];
+    setMorefestival(mockData3);
   }, []);
 
   const listData = timetableList;
@@ -93,6 +89,7 @@ const TimetableMainPage = () => {
               <FestivalListItem
                 key={item.id}
                 itemData={item}
+                onClick={() => handleMyTimetableClick(item.id)}
               />
             ))}
           </ul>
@@ -110,7 +107,7 @@ const TimetableMainPage = () => {
               <RecommendCard
                 key={item.id}
                 itemData={item}
-                onCustomizeClick={handleCustomizeClick}
+                onCustomizeClick={() => handleCustomizeClick(item.id)}
               />
             ))}
           </div>
@@ -143,6 +140,7 @@ const TimetableMainPage = () => {
               <FestivalListItem
                 key={item.id}
                 itemData={item}
+                onClick={() => handleCustomizeClick(item.id)}
               />
             ))}
           </ul>

--- a/src/pages/timetable/TimetableMainPage.tsx
+++ b/src/pages/timetable/TimetableMainPage.tsx
@@ -23,15 +23,14 @@ export interface KopisFestivalItem {
   prfstate: string; // 공연 상태
   dtguidance: string; // 시간 안내
   tkstdate: string; // 티켓 오픈일
-  // time 객체는 hour, minute 등을 포함한다고 가정
-  tksttime: { hour: number; minute: number; second: number; nano: number; }; 
+  // ... 기타 필드 (요청하신 JSON 형식에 포함된 필드를 모두 추가했습니다.)
+  tksttime: { hour: number; minute: number; second: number; nano: number; };
   typeofcon: number;
   newstate: boolean;
   locationUrl: string;
   styurls: { relatenm: string; relateurl: string; }[];
   relates: { relatenm: string; relateurl: string; }[];
   days: { date: string; open: { hour: number; minute: number; second: number; nano: number; }; close: { hour: number; minute: number; second: number; nano: number; }; }[];
-  // slot의 start/end도 time 객체를 포함한다고 가정
   slots: { date: string; stageId: string; stageName: string; stageOrder: number; artist: string; start: { hour: number; minute: number; second: number; nano: number; }; end: { hour: number; minute: number; second: number; nano: number; }; minutes: number; img: string; note: string; }[];
   fesLinks: { relatenm: string; relateurl: string; }[];
   artistPics: { date: string; relatenm: string; url: string; }[];
@@ -77,19 +76,9 @@ const TimetableMainPage = () => {
   const [error, setError] = useState<string | null>(null);
 
 
-  // 1. 커스텀 '생성' 경로 이동 함수 (FestivalItem 또는 RecommendItem 객체를 인수로 받도록 수정)
-  const handleCustomizeClick = (item: FestivalItem | RecommendItem) => { 
-    // FestivalItem과 RecommendItem의 공통 필드만 넘겨도 무방합니다.
-    navigate(`/main/timetable/customize/${item.id}`, {
-        state: { 
-            id: item.id,
-            title: item.title,
-            // FestivalItem에만 'location'이 있으므로 타입 캐스팅 및 기본값 처리
-            location: (item as FestivalItem).location || '정보 없음', 
-            date: item.date,
-            thumbnailUrl: item.thumbnailUrl
-        }
-    });
+  // 1. 커스텀 '생성' 경로 이동 함수
+  const handleCustomizeClick = (festivalId: number) => { 
+    navigate(`/main/timetable/customize/${festivalId}`);
   };
 
   // 2. 나의 타임테이블 '수정' 경로 이동 함수
@@ -179,8 +168,7 @@ const TimetableMainPage = () => {
               <FestivalListItem
                 key={item.id}
                 itemData={item}
-                // 나의 타임테이블은 ID만 넘겨도 무방
-                onClick={() => handleMyTimetableClick(item.id)} 
+                onClick={() => handleMyTimetableClick(item.id)}
               />
             ))}
           </ul>
@@ -198,8 +186,7 @@ const TimetableMainPage = () => {
               <RecommendCard
                 key={item.id}
                 itemData={item}
-                // ⭐️ 수정: item 객체 전체를 인수로 전달 ⭐️
-                onCustomizeClick={() => handleCustomizeClick(item)} 
+                onCustomizeClick={() => handleCustomizeClick(item.id)}
               />
             ))}
           </div>
@@ -238,8 +225,7 @@ const TimetableMainPage = () => {
                 <FestivalListItem
                   key={item.id}
                   itemData={item}
-                  // ⭐️ 수정: item 객체 전체를 인수로 전달 ⭐️
-                  onClick={() => handleCustomizeClick(item)}
+                  onClick={() => handleCustomizeClick(item.id)}
                 />
               ))}
             </ul>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #41 



## 📝작업 내용

초기 타임테이블 메인페이지 -> Alarm 컴포넌트 삽입
<img width="378" height="81" alt="스크린샷 2025-11-24 오전 9 21 56" src="https://github.com/user-attachments/assets/f9b8b9fe-32b7-4624-8f8e-4db422a172b5" />


 ->타임테이블 구현 사항
	•	관심 페스티벌 / 더 많은 페스티벌 클릭 시 상세 페이지 구현
	•	페스티벌 일자에 따른 공연 정보 매칭 기능 구현 완료
	•	초기화 버튼 클릭 시 모든 선택 상태 초기화 기능 구현
<img width="365" height="375" alt="스크린샷 2025-11-24 오전 9 19 54" src="https://github.com/user-attachments/assets/3153bdc5-c613-466d-8b2f-7123c87a48ca" />


스테이지 3개 이상인 경우 우측으로 배치, 횡스크롤로 확인 가능하게 수정
<img width="379" height="435" alt="스크린샷 2025-11-24 오전 9 18 17" src="https://github.com/user-attachments/assets/1aaf4c92-5d6d-4d28-93fe-eafd49a6aada" />


추가 api 연동 관련 자료 첨부
<img width="360" height="719" alt="스크린샷 2025-12-07 오전 12 43 11" src="https://github.com/user-attachments/assets/bbee1a65-e6c2-4269-847f-bbfc583f4524" />
<img width="352" height="721" alt="스크린샷 2025-12-07 오전 12 43 17" src="https://github.com/user-attachments/assets/5b9836b3-f03a-4d4f-89eb-3052947a1e77" />
<img width="346" height="719" alt="스크린샷 2025-12-07 오전 12 43 29" src="https://github.com/user-attachments/assets/0e3b9eec-56a4-45ad-8181-47112bcc007c" />










## ❌ 이슈 닫기

> ex) close #41 