### PR TITLE
Feature: Interceptor 구현

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,3 @@ VITE_GOOGLE_CLIENT_ID=840109285950-9m2unkg09l42nn9noabr9o14sr1c6drn.apps.googleu
 VITE_GOOGLE_REDIRECT_URI=http://localhost:5173/login
 
 VITE_BASE_URL = https://stage-on.duckdns.org/api/v1
-VITE_TEST_ACCESS_TOKEN = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0IiwiaXNzIjoic3RhZ2VvbiIsImlhdCI6MTc2Mzk1ODc1MCwiZXhwIjoxNzYzOTgwMzUwfQ.FKB6AVIlZVOBXr42Al1jdWVz9BnnsqBMjZT2nxdYBKY

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.9.5"
+        "react-router-dom": "^7.9.5",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -2822,7 +2823,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3642,7 +3643,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -7753,6 +7754,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.9.5"
+    "react-router-dom": "^7.9.5",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,18 +13,20 @@ import TimetableDetailPage from "./pages/timetable/TimetableDetailPage";
 import Test from "./pages/Test";
 import MyConcert from "./pages/MyConcert";
 import ConcertProfile from "./pages/ConcertProfile";
+import Callback from "./Callback";
 
 export default function App() {
   return (
     <Routes>
       <Route element={<GlobalLayout />}>
         <Route path="test" element={<Test />} />
+        <Route path="callback" element={<Callback />} />
         <Route index element={<Splash next="/Login" delayMs={3000} />} />
         <Route path="login" element={<Login />} />
         <Route path="main" element={<HomeLayout />}>
           <Route path="mybands" element={<MyBands />} />
           <Route path="home" element={<Home />} />
-          <Route path="myconcerts" element={<MyConcert/>}/>
+          <Route path="myconcerts" element={<MyConcert />} />
           <Route path="concert/:id" element={<ConcertProfile />} />
           <Route path="timetable">
             <Route index element={<TimetableMainPage />} />

--- a/src/Callback.tsx
+++ b/src/Callback.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useStore } from "../../store/store";
+import { useStore } from "./store/store";
 
 export default function Callback() {
   const location = useLocation();
@@ -10,10 +10,11 @@ export default function Callback() {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const token = params.get("token");
+    console.log(token);
     if (token) {
       login(token);
       navigate("/main/home");
     }
-  }, [location]);
+  }, [location.search]);
   return <></>;
 }

--- a/src/Callback.tsx
+++ b/src/Callback.tsx
@@ -1,11 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useStore } from "./store/store";
+import api from "./api/api";
 
+interface Result {
+  email: string;
+  name: string;
+  profileImgUrl: string;
+  firstLogin: boolean;
+}
 export default function Callback() {
+  const BASE_URL = import.meta.env.VITE_BASE_URL;
   const location = useLocation();
   const login = useStore((state) => state.login);
   const navigate = useNavigate();
+  const [checkResult, setCheckResult] = useState<Result | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -13,8 +22,30 @@ export default function Callback() {
     console.log(token);
     if (token) {
       login(token);
-      navigate("/main/home");
+      userCheck();
     }
   }, [location.search]);
+
+  useEffect(() => {
+    if (checkResult !== null) {
+      if (checkResult.firstLogin === true) {
+        navigate("/register");
+      } else {
+        navigate("/main/home");
+      }
+    }
+  }, [checkResult, navigate]);
+
+  const userCheck = async () => {
+    try {
+      const res = await api.get(`${BASE_URL}/auth/login-check`);
+
+      if (res.status === 200) {
+        setCheckResult(res.data);
+      }
+    } catch (error: any) {
+      console.log(error);
+    }
+  };
   return <></>;
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -10,7 +10,7 @@ api.interceptors.request.use(
   (config) => {
     const accessToken = localStorage.getItem("accessToken");
     if (accessToken) {
-      config.headers.Authorization = `${accessToken}`;
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;
   },

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
+const api = axios.create({
+  baseURL: BASE_URL,
+});
+
+// 요청 인터셉터
+api.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      config.headers.Authorization = `${accessToken}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -6,7 +6,6 @@ import heartSVG from "../assets/pages/search/heart.svg";
 import arrowSVG from "../assets/pages/search/arrow-right.svg";
 import { useEffect, useState } from "react";
 import Menu from "../components/Menu";
-import axios from "axios";
 import api from "../api/api";
 
 // 최근 검색어 interface
@@ -139,6 +138,7 @@ export default function Search() {
     if (inputText === "") {
       setIsSearch(false);
       fetchRecentSearch();
+      fetchRecommendSearch();
     }
   }, [inputText]);
   return (
@@ -282,7 +282,6 @@ export default function Search() {
                       <div className={searchStyle.info}>
                         <span className={searchStyle.heart}>
                           <img src={heartSVG} alt="좋아요" />
-                          999
                         </span>
                         | <span>{item.artistNames[0]}</span>
                         <span>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -7,6 +7,7 @@ import arrowSVG from "../assets/pages/search/arrow-right.svg";
 import { useEffect, useState } from "react";
 import Menu from "../components/Menu";
 import axios from "axios";
+import api from "../api/api";
 
 // 최근 검색어 interface
 interface RecentSearch {
@@ -60,18 +61,12 @@ export default function Search() {
   const [onMenu, setOnMenu] = useState<boolean>(false);
   const [animateMenu, setAnimateMenu] = useState<boolean>(false);
 
-  // 테스트 액세스 토큰
-  const REST_API_KEY = import.meta.env.VITE_TEST_ACCESS_TOKEN;
   const BASE_URL = import.meta.env.VITE_BASE_URL;
 
   // 최근 검색어 불러오는 함수
   const fetchRecentSearch = async () => {
     try {
-      const res = await axios.get(`${BASE_URL}/search/history`, {
-        headers: {
-          Authorization: `Bearer ${REST_API_KEY}`,
-        },
-      });
+      const res = await api.get(`${BASE_URL}/search/history`, {});
 
       if (res.status === 200) {
         setRecent(res.data);
@@ -81,11 +76,7 @@ export default function Search() {
   // 최근 검색어 삭제 함수
   const deleteRecent = async (id: number) => {
     try {
-      const res = await axios.delete(`${BASE_URL}/search/history/${id}`, {
-        headers: {
-          Authorization: `Bearer ${REST_API_KEY}`,
-        },
-      });
+      const res = await api.delete(`${BASE_URL}/search/history/${id}`, {});
       if (res.status == 200) {
         alert(res.data);
       }
@@ -98,11 +89,7 @@ export default function Search() {
   // 추천 검색어 불러오는 함수
   const fetchRecommendSearch = async () => {
     try {
-      const res = await axios.get(`${BASE_URL}/recommend`, {
-        headers: {
-          Authorization: `Bearer ${REST_API_KEY}`,
-        },
-      });
+      const res = await api.get(`${BASE_URL}/recommend`, {});
 
       if (res.status === 200) {
         setRecommendList(res.data);
@@ -119,13 +106,8 @@ export default function Search() {
   // 검색 함수
   const handleSearch = async (inputText: string) => {
     try {
-      const res = await axios.get<ApiResponse>(
-        `${BASE_URL}/search?query=${inputText}`,
-        {
-          headers: {
-            Authorization: `Bearer ${REST_API_KEY}`,
-          },
-        }
+      const res = await api.get<ApiResponse>(
+        `${BASE_URL}/search?query=${inputText}`
       );
       if (res.status === 200) {
         const data = res.data as ApiResponse;

--- a/src/pages/auth/Callback.tsx
+++ b/src/pages/auth/Callback.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useStore } from "../../store/store";
+
+export default function Callback() {
+  const location = useLocation();
+  const login = useStore((state) => state.login);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const token = params.get("token");
+    if (token) {
+      login(token);
+      navigate("/main/home");
+    }
+  }, [location]);
+  return <></>;
+}

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -8,8 +8,8 @@ const Login = () => {
   const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
   const kakaolink = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
-  const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-  const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
+  // const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  // const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
   // const googlelink = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email%20profile`;
   const googlelink = "https://stage-on.duckdns.org/oauth2/authorization/google";
   const handleGoogleLogin = () => {

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,7 +1,7 @@
 import loginlogo from "../../assets/auth/LoginLogo.svg";
 import loginStyle from "../../css/pages/login.module.css";
-import googlelogo from  "../../assets/auth/Google.svg";
-import kakaologo from "../../assets/auth/KaKao.svg"
+import googlelogo from "../../assets/auth/Google.svg";
+import kakaologo from "../../assets/auth/KaKao.svg";
 
 const Login = () => {
   const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
@@ -10,38 +10,52 @@ const Login = () => {
 
   const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
   const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
-  const googlelink = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email%20profile`;
-
+  // const googlelink = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email%20profile`;
+  const googlelink = "https://stage-on.duckdns.org/oauth2/authorization/google";
   const handleGoogleLogin = () => {
     window.location.href = googlelink;
-  }
+  };
 
   const handleKaKaoLogin = () => {
     window.location.href = kakaolink;
-  }
+  };
 
   return (
-  <div className={loginStyle.fixedDiv}>
-    <img
-      src={loginlogo}
-      alt="로그인화면로고"
-      className={loginStyle.loginLogo}
-    />
-    <span className={loginStyle.loginText}>로그인</span>
+    <div className={loginStyle.fixedDiv}>
+      <img
+        src={loginlogo}
+        alt="로그인화면로고"
+        className={loginStyle.loginLogo}
+      />
+      <span className={loginStyle.loginText}>로그인</span>
 
-    <div className={loginStyle.loginButton}>
-    <button type="button"
-    onClick={handleGoogleLogin}
-    className={loginStyle.GoogleLogin}>
-    <img src={googlelogo} alt="구글로고" className={loginStyle.googleLogo}/>
-    Google 계정으로 계속</button>
+      <div className={loginStyle.loginButton}>
+        <button
+          type="button"
+          onClick={handleGoogleLogin}
+          className={loginStyle.GoogleLogin}
+        >
+          <img
+            src={googlelogo}
+            alt="구글로고"
+            className={loginStyle.googleLogo}
+          />
+          Google 계정으로 계속
+        </button>
 
-    <button type="button"
-    onClick={handleKaKaoLogin}
-    className={loginStyle.KaKaoLogin}>
-      <img src={kakaologo} alt="카카오로고" className={loginStyle.kakaoLogo}/>
-      KaKao 계정으로 계속</button>
-    </div>
+        <button
+          type="button"
+          onClick={handleKaKaoLogin}
+          className={loginStyle.KaKaoLogin}
+        >
+          <img
+            src={kakaologo}
+            alt="카카오로고"
+            className={loginStyle.kakaoLogo}
+          />
+          KaKao 계정으로 계속
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { create } from "zustand";
+
+// 상태 타입 정의
+interface Store {
+  accessToken: string | null;
+
+  login: (accessToken: string) => void;
+  logout: () => void;
+  isLogin: () => boolean;
+}
+
+// zustand 스토어 생성
+const useStore = create<Store>((set, get) => ({
+  accessToken: null,
+
+  login: (accessToken) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("accessToken", accessToken);
+    }
+
+    set(() => ({
+      accessToken,
+    }));
+  },
+
+  logout: () => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("accessToken");
+    }
+
+    set(() => ({
+      accessToken: null,
+    }));
+  },
+
+  isLogin: () => get().accessToken !== null,
+}));
+const useLocalStorage = () => {
+  const navigate = useNavigate(); // 리디렉션을 위한 navigate 훅 사용
+  const { login } = useStore();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const storedAccessToken = localStorage.getItem("accessToken");
+
+      if (storedAccessToken) {
+        // localStorage에서 값이 있으면 상태에 반영
+        login(storedAccessToken);
+      } else {
+        // 로그인하지 않은 경우 로그인 페이지로 리디렉션
+        navigate("/login");
+      }
+    }
+  }, [login, navigate]); // 로그인 상태 변경 시 다시 실행
+};
+
+export { useStore, useLocalStorage };


### PR DESCRIPTION
## #️⃣연관된 이슈

- #51 

## 📝작업 내용

- 구글 로그인 경로 수정
- 현재 로그인 방식으론 url에 token이 노출됨 => 임시 방편으로 callback페이지 만든 후 토큰 저장 후 /main/home으로 이동
- 로그인 인터셉터 & store 구현

api 통신할 때, 
```typescript
const res = await api.get(`${BASE_URL}/search/history`, {});
```
이런 식으로 앞에 api를 붙이면 됩니다. 그럼 자동으로 header에 토큰 담아서 전송, 만약 401뜨면 로그인 창으로 이동(만료됐단 의미)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ❌ 이슈 닫기

- close #51 