### PR TITLE
Feature : 공연프로필 상세조회, 좋아요 취소/좋아요 추가 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
           <Route path="mybands" element={<MyBands />} />
           <Route path="home" element={<Home />} />
           <Route path="myconcerts" element={<MyConcert />} />
-          <Route path="concert/:id" element={<ConcertProfile />} />
+         <Route path="concert/:mt20id" element={<ConcertProfile />} />
           <Route path="timetable">
             <Route index element={<TimetableMainPage />} />
             <Route path=":id" element={<TimetableDetailPage />} />

--- a/src/api/myConcerts.ts
+++ b/src/api/myConcerts.ts
@@ -1,4 +1,3 @@
-// src/api/myConcertsApi.ts
 import api from "./api";
 
 export interface MyConcertResponse {
@@ -8,7 +7,7 @@ export interface MyConcertResponse {
   prfpdfrom: string; 
   prfpdto: string;   
   fcltynm: string;  
-}
+  mt20id: string; }
 
 // MY Concerts 조회 API
 export const getMyConcerts = async (): Promise<MyConcertResponse[]> => {

--- a/src/api/performanceDetail.ts
+++ b/src/api/performanceDetail.ts
@@ -1,0 +1,39 @@
+import api from "./api";
+
+export interface StyUrl {
+  relatenm: string;    
+  relateurl: string;    
+}
+
+export interface RelateTicket {
+  relatenm: string;    
+  relateurl: string;   
+}
+
+export interface PerformanceDetail {
+  id: number;
+  mt20id: string;
+  prfnm: string;
+  prfpdfrom: string;
+  prfpdto: string;
+  fcltynm: string;
+  prfruntime: string;
+  prfage: string;
+  pcseguidance: string;
+  poster: string;
+  prfstate: string;
+  dtguidance: string;
+  tkstdate: string;
+  tksttime: string;
+  typeofcon: number;
+  styurls: StyUrl[];
+  relates: RelateTicket[];
+  locationUrl: string;
+}
+
+export const getPerformanceDetail = async (mt20id: string) => {
+  const res = await api.get<PerformanceDetail>(
+    `/kopis/performances/detail/${mt20id}`
+  );
+  return res.data;
+};

--- a/src/api/performanceLike.ts
+++ b/src/api/performanceLike.ts
@@ -1,0 +1,13 @@
+import api from "./api";
+
+// 공연 좋아요 등록 (POST)
+export const likePerformance = async (performanceId: number): Promise<void> => {
+  await api.post(`/likes/performances/${performanceId}`);
+};
+
+// 공연 좋아요 취소 (DELETE)
+export const cancelLikePerformance = async (
+  performanceId: number
+): Promise<void> => {
+  await api.delete(`/likes/performances/${performanceId}`);
+};

--- a/src/components/MyConcertsCard.tsx
+++ b/src/components/MyConcertsCard.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 
 interface MyConcertsCardProps {
   id: number;
+  mt20id: string;
   festivalName: string;
   location: string;
   date: string;
@@ -17,6 +18,7 @@ interface MyConcertsCardProps {
 
 const MyConcertsCard = ({
   id,
+  mt20id,
   festivalName,
   location,
   date,
@@ -31,8 +33,11 @@ const MyConcertsCard = ({
 
   return (
     <>
-    <Link to={`/main/concert/${id}`}
-     className={myConcertsStyle.cardLink}>
+  <Link
+      to={`/main/concert/${mt20id}`}
+      state={{ liked }}               
+      className={myConcertsStyle.cardLink}
+    >
       <div className={myConcertsStyle.concertCardContainer}>
         <img src={concertimage} className={myConcertsStyle.concertImg} />
 

--- a/src/components/MyConcertsCard.tsx
+++ b/src/components/MyConcertsCard.tsx
@@ -13,10 +13,12 @@ interface MyConcertsCardProps {
   location: string;
   date: string;
   liked: boolean;
+  posterUrl: string;
   onToggle: (id: number) => void;
 }
 
 const MyConcertsCard = ({
+   posterUrl,
   id,
   mt20id,
   festivalName,
@@ -39,7 +41,10 @@ const MyConcertsCard = ({
       className={myConcertsStyle.cardLink}
     >
       <div className={myConcertsStyle.concertCardContainer}>
-        <img src={concertimage} className={myConcertsStyle.concertImg} />
+          <img
+          src={posterUrl || concertimage}
+          className={myConcertsStyle.concertImg}
+        />
 
         <div className={myConcertsStyle.concertCardColumn}>
           <span className={myConcertsStyle.festivalName}>{festivalName}</span>

--- a/src/css/pages/concertprofile.module.css
+++ b/src/css/pages/concertprofile.module.css
@@ -3,6 +3,11 @@
   margin: -20px; 
 }
 
+.infoSection2{
+  background: #000;
+  margin: -20px;
+}
+
 .header {
     padding: 12px 0;
     display: flex;

--- a/src/css/pages/concertprofile.module.css
+++ b/src/css/pages/concertprofile.module.css
@@ -27,6 +27,10 @@
   display: block;
   width: max-content;
   line-height: 1.2;
+  max-width: 70%;    
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .posterImg {

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -13,6 +13,7 @@ interface Recommend {
 // 공연 검색 결과 interface
 interface PerformanceItem {
   performanceId: number;
+   mt20id: string;
   title: string;
   posterUrl: string;
   startDate: string;

--- a/src/pages/ConcertProfile.tsx
+++ b/src/pages/ConcertProfile.tsx
@@ -1,4 +1,3 @@
-// src/pages/ConcertProfile.tsx
 import { useEffect, useState } from "react";
 import { HiChevronLeft } from "react-icons/hi2";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
@@ -8,9 +7,11 @@ import posterPlaceholder from "../assets/poster image.svg";
 import heartFilled from "../assets/timetable/heart.svg";
 import heartEmpty from "../assets/myconcertheartEmpty.svg";
 import bandListImg from "../assets/bandlistimg.svg";
-
-import { getPerformanceDetail, type PerformanceDetail } 
-  from "../api/performanceDetail";
+import { likePerformance, cancelLikePerformance } from "../api/performanceLike";
+import {
+  getPerformanceDetail,
+  type PerformanceDetail,
+} from "../api/performanceDetail";
 
 type RouteParams = {
   mt20id?: string;
@@ -34,8 +35,33 @@ const ConcertProfile = () => {
   const state = location.state as LocationState | null;
 
   const [liked, setLiked] = useState<boolean>(state?.liked ?? true);
+  const [isProcessing, setIsProcessing] = useState(false);
   const [detail, setDetail] = useState<PerformanceDetail | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const handleToggleLike = async () => {
+    if (!detail) return;
+    if (isProcessing) return;
+
+    const performanceId = detail.id;
+
+    try {
+      setIsProcessing(true);
+
+      if (liked) {
+        await cancelLikePerformance(performanceId);
+        setLiked(false);
+      } else {
+        await likePerformance(performanceId);
+        setLiked(true);
+      }
+    } catch (error) {
+      console.error("관심 공연 처리 실패:", error);
+      alert("관심 공연 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
 
   useEffect(() => {
     if (!mt20id) return;
@@ -63,9 +89,7 @@ const ConcertProfile = () => {
             className={concertProfileStyle.Vector}
             onClick={() => navigate("/main/myconcerts")}
           />
-          <span className={concertProfileStyle.concertName}>
-            로딩 중...
-          </span>
+          <span className={concertProfileStyle.concertName}>로딩 중...</span>
         </div>
       </div>
     );
@@ -102,8 +126,7 @@ const ConcertProfile = () => {
     locationUrl,
   } = detail;
 
-  const ticketSite = relates?.[0]; 
-  
+  const ticketSite = relates?.[0];
 
   const handleOpenTicket = () => {
     if (ticketSite?.relateurl) {
@@ -135,41 +158,44 @@ const ConcertProfile = () => {
       />
 
       <div className={concertProfileStyle.SectionWrapper}>
-        {/* 상단 기본 정보 + 좋아요 */}
         <div className={concertProfileStyle.infoSection}>
           <div className={concertProfileStyle.leftBlock}>
             <span className={concertProfileStyle.title}>{prfnm}</span>
             <span className={concertProfileStyle.location}>{fcltynm}</span>
           </div>
+<div className={concertProfileStyle.rightBlock}>
 
-          <div className={concertProfileStyle.rightBlock}>
-            <div className={concertProfileStyle.likeRow}>
-              <img
-                src={liked ? heartFilled : heartEmpty}
-                className={concertProfileStyle.heartIcon}
-                onClick={() => {
-                  // 여기서 나중에 좋아요 API 연동
-                  setLiked((prev) => !prev);
-                }}
-              />
-            </div>
+  <div className={concertProfileStyle.likeRow}>
+    <img
+      src={liked ? heartFilled : heartEmpty}
+      className={concertProfileStyle.heartIcon}
+    />
+  </div>
 
-            {liked ? (
-              <button className={concertProfileStyle.interestButton}>
-                나의 관심 공연
-              </button>
-            ) : (
-              <button
-                className={concertProfileStyle.interestButtonInactive}
-                onClick={() => setLiked(true)}
-              >
-                관심 공연으로 추가하기
-              </button>
-            )}
+    {liked ? (
+      <button
+        className={concertProfileStyle.interestButton}
+        onClick={handleToggleLike}
+        disabled={isProcessing}
+      >
+        나의 관심 공연
+      </button>
+    ) : (
+      <button
+        className={concertProfileStyle.interestButtonInactive}
+        onClick={handleToggleLike}
+        disabled={isProcessing}
+      >
+        관심 공연으로 추가하기
+      </button>
+    )}
+  </div>
+
           </div>
         </div>
 
         {/* 상세 정보 섹션 */}
+        <div className={concertProfileStyle.infoSection2}>
         <div className={concertProfileStyle.detailSection}>
           <div className={concertProfileStyle.detailLeft}>
             <div className={concertProfileStyle.detailTitle}>상세 정보</div>
@@ -200,10 +226,7 @@ const ConcertProfile = () => {
           </div>
 
           <div className={concertProfileStyle.detailRight}>
-            <button
-              className={concertProfileStyle.detailButton}
-              // 나중에 타임테이블 커스텀 페이지로 이동
-            >
+            <button className={concertProfileStyle.detailButton}>
               타임테이블 커스텀
             </button>
 
@@ -251,7 +274,7 @@ const ConcertProfile = () => {
           </div>
         </div>
       </div>
-    </div>
+</div>
   );
 };
 

--- a/src/pages/ConcertProfile.tsx
+++ b/src/pages/ConcertProfile.tsx
@@ -1,140 +1,256 @@
-import concertProfileStyle from "../css/pages/concertprofile.module.css";
+// src/pages/ConcertProfile.tsx
+import { useEffect, useState } from "react";
 import { HiChevronLeft } from "react-icons/hi2";
-import posterImage from "../assets/poster image.svg";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+
+import concertProfileStyle from "../css/pages/concertprofile.module.css";
+import posterPlaceholder from "../assets/poster image.svg";
 import heartFilled from "../assets/timetable/heart.svg";
-import bandListImg from "../assets/bandlistimg.svg";
-import { useNavigate } from "react-router-dom";
-import { useState } from "react";
 import heartEmpty from "../assets/myconcertheartEmpty.svg";
+import bandListImg from "../assets/bandlistimg.svg";
+
+import { getPerformanceDetail, type PerformanceDetail } 
+  from "../api/performanceDetail";
+
+type RouteParams = {
+  mt20id?: string;
+};
+
+type LocationState = {
+  liked?: boolean;
+};
+
+const formatDateRange = (from?: string, to?: string) => {
+  if (!from || !to) return "";
+  const [fromY, fromM, fromD] = from.split("-");
+  const [, toM, toD] = to.split("-");
+  return `${fromY}.${fromM}.${fromD} - ${toM}.${toD}`;
+};
 
 const ConcertProfile = () => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
+  const { mt20id } = useParams<RouteParams>();
+  const location = useLocation();
+  const state = location.state as LocationState | null;
 
-    const [liked, setLiked] = useState(true);
+  const [liked, setLiked] = useState<boolean>(state?.liked ?? true);
+  const [detail, setDetail] = useState<PerformanceDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!mt20id) return;
+
+    const fetchDetail = async () => {
+      try {
+        const data = await getPerformanceDetail(mt20id);
+        setDetail(data);
+      } catch (e) {
+        console.error(e);
+        alert("공연 상세 정보를 불러오지 못했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDetail();
+  }, [mt20id]);
+
+  if (loading) {
+    return (
+      <div className={concertProfileStyle.page}>
+        <div className={concertProfileStyle.header}>
+          <HiChevronLeft
+            className={concertProfileStyle.Vector}
+            onClick={() => navigate("/main/myconcerts")}
+          />
+          <span className={concertProfileStyle.concertName}>
+            로딩 중...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className={concertProfileStyle.page}>
+        <div className={concertProfileStyle.header}>
+          <HiChevronLeft
+            className={concertProfileStyle.Vector}
+            onClick={() => navigate("/main/myconcerts")}
+          />
+          <span className={concertProfileStyle.concertName}>
+            공연 정보를 찾을 수 없습니다.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const {
+    prfnm,
+    prfpdfrom,
+    prfpdto,
+    fcltynm,
+    prfruntime,
+    pcseguidance,
+    poster,
+    tkstdate,
+    tksttime,
+    styurls,
+    relates,
+    locationUrl,
+  } = detail;
+
+  const ticketSite = relates?.[0]; 
+  
+
+  const handleOpenTicket = () => {
+    if (ticketSite?.relateurl) {
+      window.open(ticketSite.relateurl, "_blank");
+    }
+  };
+
+  const handleOpenLocation = () => {
+    if (locationUrl) {
+      window.open(locationUrl, "_blank");
+    }
+  };
 
   return (
-    
     <div className={concertProfileStyle.page}>
+      {/* 헤더 */}
       <div className={concertProfileStyle.header}>
-        {/* 아이콘 클릭시 My Concerts 페이지로 이동 */}
-        <HiChevronLeft 
-        className={concertProfileStyle.Vector} 
-        onClick={() => navigate("/main/myconcerts")} 
+        <HiChevronLeft
+          className={concertProfileStyle.Vector}
+          onClick={() => navigate("/main/myconcerts")}
         />
-        <span className={concertProfileStyle.concertName}>
-          COUNTDOWN FANTASY 2025-2026
-        </span>
+        <span className={concertProfileStyle.concertName}>{prfnm}</span>
       </div>
-    
-      <img src={posterImage} className={concertProfileStyle.posterImg} />
-    <div className={concertProfileStyle.SectionWrapper}>
-      <div className={concertProfileStyle.infoSection}>
-        <div className={concertProfileStyle.leftBlock}>
-          <span className={concertProfileStyle.title}>
-            COUNTDOWN <br />
-            FANTSY <br />
-            2025-2026
-          </span>
 
-          <span className={concertProfileStyle.location}>일산 킨텍스</span>
-        </div>
+      {/* 포스터 */}
+      <img
+        src={poster || posterPlaceholder}
+        className={concertProfileStyle.posterImg}
+      />
 
-        <div className={concertProfileStyle.rightBlock}>
-       
-          <div className={concertProfileStyle.likeRow}>
-            <img
-              src={liked ? heartFilled : heartEmpty}
-              className={concertProfileStyle.heartIcon}
-           
-              onClick={() => {
-                if (liked) setLiked(false);
-              }}
-            />
-          
+      <div className={concertProfileStyle.SectionWrapper}>
+        {/* 상단 기본 정보 + 좋아요 */}
+        <div className={concertProfileStyle.infoSection}>
+          <div className={concertProfileStyle.leftBlock}>
+            <span className={concertProfileStyle.title}>{prfnm}</span>
+            <span className={concertProfileStyle.location}>{fcltynm}</span>
           </div>
 
-          {liked ? (
-            // 좋아요 된 상태
-            <button className={concertProfileStyle.interestButton}>
-              나의 관심 공연
-            </button>
-          ) : (
-            // 좋아요 안 된 상태
-            <button
-              className={concertProfileStyle.interestButtonInactive}
-              onClick={() => setLiked(true)} 
-            >
-              관심 공연으로 추가하기
-            </button>
-          )}
+          <div className={concertProfileStyle.rightBlock}>
+            <div className={concertProfileStyle.likeRow}>
+              <img
+                src={liked ? heartFilled : heartEmpty}
+                className={concertProfileStyle.heartIcon}
+                onClick={() => {
+                  // 여기서 나중에 좋아요 API 연동
+                  setLiked((prev) => !prev);
+                }}
+              />
+            </div>
+
+            {liked ? (
+              <button className={concertProfileStyle.interestButton}>
+                나의 관심 공연
+              </button>
+            ) : (
+              <button
+                className={concertProfileStyle.interestButtonInactive}
+                onClick={() => setLiked(true)}
+              >
+                관심 공연으로 추가하기
+              </button>
+            )}
+          </div>
         </div>
-      </div>
 
-
-            <div className={concertProfileStyle.detailSection}>
-        <div className={concertProfileStyle.detailLeft}>
+        {/* 상세 정보 섹션 */}
+        <div className={concertProfileStyle.detailSection}>
+          <div className={concertProfileStyle.detailLeft}>
             <div className={concertProfileStyle.detailTitle}>상세 정보</div>
 
             <div className={concertProfileStyle.detailItem}>
-            <span className={concertProfileStyle.label}>일시</span>
-            <span className={concertProfileStyle.value}>2025.12.30 - 12.31</span>
+              <span className={concertProfileStyle.label}>일시</span>
+              <span className={concertProfileStyle.value}>
+                {formatDateRange(prfpdfrom, prfpdto)}
+              </span>
             </div>
 
             <div className={concertProfileStyle.detailItem}>
-            <span className={concertProfileStyle.label}>티켓</span>
-            <span className={concertProfileStyle.value}>전석 비지정석 110,000원</span>
+              <span className={concertProfileStyle.label}>티켓</span>
+              <span className={concertProfileStyle.value}>{pcseguidance}</span>
             </div>
 
             <div className={concertProfileStyle.detailItem}>
-            <span className={concertProfileStyle.label}>예매일</span>
-            <span className={concertProfileStyle.value}>2025.10.02(목) 18:00시</span>
+              <span className={concertProfileStyle.label}>예매일</span>
+              <span className={concertProfileStyle.value}>
+                {tkstdate} {tksttime}
+              </span>
             </div>
 
             <div className={concertProfileStyle.detailItem}>
-            <span className={concertProfileStyle.label}>러닝타임</span>
-            <span className={concertProfileStyle.value}>120분</span>
+              <span className={concertProfileStyle.label}>러닝타임</span>
+              <span className={concertProfileStyle.value}>{prfruntime}</span>
             </div>
+          </div>
+
+          <div className={concertProfileStyle.detailRight}>
+            <button
+              className={concertProfileStyle.detailButton}
+              // 나중에 타임테이블 커스텀 페이지로 이동
+            >
+              타임테이블 커스텀
+            </button>
+
+            <button
+              className={concertProfileStyle.detailButton}
+              onClick={handleOpenTicket}
+            >
+              예매처 바로 가기
+            </button>
+
+            <button
+              className={concertProfileStyle.detailButton}
+              onClick={handleOpenLocation}
+            >
+              공연장 위치 보기
+            </button>
+          </div>
         </div>
 
-        <div className={concertProfileStyle.detailRight}>
-            <button className={concertProfileStyle.detailButton}>타임테이블 커스텀</button>
-            <button className={concertProfileStyle.detailButton}>예매처 바로 가기</button>
-            <button className={concertProfileStyle.detailButton}>공연장 위치 보기</button>
-           
+        {/* 밴드 라인업 */}
+        <div className={concertProfileStyle.bandLineupSection}>
+          <div className={concertProfileStyle.bandLineupTitle}>
+            출연 밴드 라인업
+          </div>
+
+          <div className={concertProfileStyle.bandList}>
+            {styurls && styurls.length > 0 ? (
+              styurls.map((s) => (
+                <div
+                  key={s.relatenm}
+                  className={concertProfileStyle.bandItem}
+                >
+                  <img
+                    src={s.relateurl || bandListImg}
+                    className={concertProfileStyle.bandAvatar}
+                  />
+                  <span className={concertProfileStyle.bandName}>
+                    {s.relatenm}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <div>출연진 정보가 아직 등록되지 않았습니다.</div>
+            )}
+          </div>
         </div>
-        </div>
-    
-<div className={concertProfileStyle.bandLineupSection}>
-  <div className={concertProfileStyle.bandLineupTitle}>출연 밴드 라인업</div>
-
-  <div className={concertProfileStyle.bandList}>
-    <div className={concertProfileStyle.bandItem}>
-      <img src={bandListImg} className={concertProfileStyle.bandAvatar} />
-      <span className={concertProfileStyle.bandName}>심아일랜드</span>
-    </div>
-
-    <div className={concertProfileStyle.bandItem}>
-      <img src={bandListImg} className={concertProfileStyle.bandAvatar} />
-      <span className={concertProfileStyle.bandName}>CNBLUE</span>
-    </div>
-
-    <div className={concertProfileStyle.bandItem}>
-      <img src={bandListImg} className={concertProfileStyle.bandAvatar} />
-      <span className={concertProfileStyle.bandName}>극동아시아<br/>타이거즈</span>
-    </div>
-
-    <div className={concertProfileStyle.bandItem}>
-      <img src={bandListImg} className={concertProfileStyle.bandAvatar} />
-      <span className={concertProfileStyle.bandName}>ADOY</span>
-    </div>
-
-    <div className={concertProfileStyle.bandItem}>
-      <img src={bandListImg} className={concertProfileStyle.bandAvatar} />
-      <span className={concertProfileStyle.bandName}>유형서점</span>
-    </div>
-  </div>
-</div>
-    </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/ConcertProfile.tsx
+++ b/src/pages/ConcertProfile.tsx
@@ -34,7 +34,7 @@ const ConcertProfile = () => {
   const location = useLocation();
   const state = location.state as LocationState | null;
 
-  const [liked, setLiked] = useState<boolean>(state?.liked ?? true);
+  const [liked, setLiked] = useState<boolean>(state?.liked ?? false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [detail, setDetail] = useState<PerformanceDetail | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/pages/MyConcert.tsx
+++ b/src/pages/MyConcert.tsx
@@ -17,7 +17,8 @@ interface Concert {
   festivalName: string;
   location: string;   
   date: string;       
-  liked: boolean;      
+  liked: boolean;
+   posterUrl: string;      
 }
 
 
@@ -48,6 +49,7 @@ const MyConcert = () => {
           location: c.fcltynm,
           date: formatDateRange(c.prfpdfrom, c.prfpdto),
           liked: true,
+           posterUrl: c.posterUrl,
         }));
 
         setConcerts(mapped);
@@ -89,6 +91,7 @@ const MyConcert = () => {
       {!loading &&
         concerts.map((concert) => (
           <MyConcertsCard
+           posterUrl={concert.posterUrl} 
             key={concert.id}
             id={concert.id}
               mt20id={concert.mt20id}

--- a/src/pages/MyConcert.tsx
+++ b/src/pages/MyConcert.tsx
@@ -12,7 +12,8 @@ import type { MyConcertResponse } from "../api/myConcerts";
 
 
 interface Concert {
-  id: number;        
+  id: number;     
+  mt20id: string;    
   festivalName: string;
   location: string;   
   date: string;       
@@ -39,9 +40,10 @@ const MyConcert = () => {
     const fetchMyConcerts = async () => {
       try {
         const data: MyConcertResponse[] = await getMyConcerts();
-
+           console.log("likes/my/concerts 응답", data);
         const mapped: Concert[] = data.map((c) => ({
           id: c.performanceId,
+           mt20id: c.mt20id,
           festivalName: c.title,
           location: c.fcltynm,
           date: formatDateRange(c.prfpdfrom, c.prfpdto),
@@ -89,6 +91,7 @@ const MyConcert = () => {
           <MyConcertsCard
             key={concert.id}
             id={concert.id}
+              mt20id={concert.mt20id}
             festivalName={concert.festivalName}
             location={concert.location}
             date={concert.date}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -204,11 +204,15 @@ export default function Search() {
             {onFestival && (
               <>
                 {performances?.items.map((item, index) => (
-                  <li
-                    className={searchStyle.searchResultItem}
-                    key={item.performanceId}
-                  onClick={() => navigate(`/main/concert/${item.mt20id}`)}
-                  >
+                        <li
+                          className={searchStyle.searchResultItem}
+                          key={item.performanceId}
+                        onClick={() =>  navigate(`/main/concert/${item.mt20id}`, {
+                state: { liked: item.liked },  
+              })
+            }
+          >
+                
                      
                     <img src={item.posterUrl} className={searchStyle.testImg} />
                     <div className={searchStyle.titleAndInfo}>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import Menu from "../components/Menu";
 import useSearch from "../hooks/useSearch";
 import useMyBands from "../hooks/useMyBands";
+import { likePerformance, cancelLikePerformance } from "../api/performanceLike";
 
 export default function Search() {
   // 입력된 검색어
@@ -209,20 +210,24 @@ export default function Search() {
                     <div className={searchStyle.titleAndInfo}>
                       <span className={searchStyle.title}>{item.title}</span>
                       <div className={searchStyle.info}>
-                        <img
-                          src={performanceLiked[index] ? fullHeart : emptyHeart}
-                          alt="좋아요"
-                          onClick={() => {
-                            if (performanceLiked[index]) {
-                              // 공연 좋아요 취소 함수
-                            } else {
-                              // 공연 좋아요 추가 함수
-                            }
-                            setPerformanceLiked((prev) =>
-                              prev.map((v, i) => (i === index ? !v : v))
-                            );
-                          }}
-                        />
+                       <img
+                        src={performanceLiked[index] ? fullHeart : emptyHeart}
+                        alt="좋아요"
+                        onClick={async () => {
+                          const performanceId = item.performanceId;
+
+                          if (performanceLiked[index]) {
+                            await cancelLikePerformance(performanceId);
+                          } else {
+                            await likePerformance(performanceId);
+                          }
+
+                          setPerformanceLiked((prev) =>
+                            prev.map((v, i) => (i === index ? !v : v))
+                          );
+                        }}
+                      />
+
                         <span className={searchStyle.innerText}>|</span>
                         <span>{item.artistNames[0]}</span>
                         <span className={searchStyle.innerText}>|</span>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -10,7 +10,7 @@ import Menu from "../components/Menu";
 import useSearch from "../hooks/useSearch";
 import useMyBands from "../hooks/useMyBands";
 import { likePerformance, cancelLikePerformance } from "../api/performanceLike";
-import { Link, useNavigate } from "react-router-dom"; 
+import { useNavigate } from "react-router-dom"; 
 
 export default function Search() {
    const navigate = useNavigate(); 

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -10,8 +10,10 @@ import Menu from "../components/Menu";
 import useSearch from "../hooks/useSearch";
 import useMyBands from "../hooks/useMyBands";
 import { likePerformance, cancelLikePerformance } from "../api/performanceLike";
+import { Link, useNavigate } from "react-router-dom"; 
 
 export default function Search() {
+   const navigate = useNavigate(); 
   // 입력된 검색어
   const [inputText, setInputText] = useState<string>("");
   // 공연 탭인지 아닌지
@@ -205,7 +207,9 @@ export default function Search() {
                   <li
                     className={searchStyle.searchResultItem}
                     key={item.performanceId}
+                  onClick={() => navigate(`/main/concert/${item.mt20id}`)}
                   >
+                     
                     <img src={item.posterUrl} className={searchStyle.testImg} />
                     <div className={searchStyle.titleAndInfo}>
                       <span className={searchStyle.title}>{item.title}</span>
@@ -213,7 +217,8 @@ export default function Search() {
                        <img
                         src={performanceLiked[index] ? fullHeart : emptyHeart}
                         alt="좋아요"
-                        onClick={async () => {
+                        onClick={async (e) => {
+                          e.stopPropagation();
                           const performanceId = item.performanceId;
 
                           if (performanceLiked[index]) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #64 

## 📝작업 내용
-  ````myconcerts```에서 해당 mt20id 를 통해 공연 상세 프로필 조회
- 해당 공연 프로필내에서 관심 공연 등록, 취소 
- 검색 기능에서 좋아요 함수 추가
- ```myconcerts```에서 이미지 url 표시 안되는 부분 수정

### 스크린샷 (선택)

### My Concerts
<img width="583" height="1251" alt="image" src="https://github.com/user-attachments/assets/89a29761-705b-4ca4-ba81-7b66a10e9274" />

### 공연 일정 상세조회 프로필
<img width="577" height="1249" alt="image" src="https://github.com/user-attachments/assets/8b87b616-72ff-41f5-996d-75566162188f" />


## 💬리뷰 요구사항(선택)

> 타임테이블 완성되면 해당 공연의 타임테이블 커스텀으로 이동되게 수정해주세요!
백엔드에서 데이터를 넣어주지 않는 부분(ex. 공연장 위치 보기) 는 클릭해도 이동할 수 없습니다. ( 넣어주신다합니다!)

## ❌ 이슈 닫기

> ex) close #64