### PR TITLE
Feat : Home 화면에서 공연 카드 클릭 시 공연 프로필로 이동

### DIFF
--- a/src/components/BandCard.tsx
+++ b/src/components/BandCard.tsx
@@ -1,7 +1,9 @@
+import { useNavigate } from "react-router-dom";
 import bandcardStyle from "../css/components/bandcard.module.css";
 import NewCard from "./NewCard";
 
 type Concert = {
+  mt20id: string;
   id: number;
   name: string;
   date: string;
@@ -14,9 +16,20 @@ type BandCardProps = {
 };
 
 const BandCard = ({ concert }: BandCardProps) => {
+  console.log("BandCard render", concert.mt20id); 
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    console.log("card clicked!", concert.mt20id);
+    navigate(`/main/concert/${concert.mt20id}`);
+  };
+
   return (
-    <div className={bandcardStyle.bandcardContainer}>
-    
+    <div className={bandcardStyle.bandcardContainer}
+    onClick={handleClick}
+      role="button"
+    >
+      
       <div className={bandcardStyle.imageWrapper}>
         <img
           src={concert.image}

--- a/src/components/BandCardName.tsx
+++ b/src/components/BandCardName.tsx
@@ -3,6 +3,7 @@ import BandCard from "./BandCard";
 
 type Concert = {
   id: number;
+  mt20id: string;
   name: string;
   date: string;
   image: string;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import type { KopisBand, KopisPerformance } from "../api/kopisApi";
 
 // 콘서트 타입 정의
 type Concert = {
+  mt20id: string;
   id: number;     
   name: string;
   date: string;
@@ -29,7 +30,7 @@ const mapPerformanceToConcert = (perf: KopisPerformance): Concert => {
 
   return {
   id: Number(perf.mt20id),        
-
+ mt20id: perf.mt20id, 
     name: perf.prfnm,
     date: period,
     image: perf.poster || concertimage, 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #70 

## 📝작업 내용

> Home 화면에서 관심 밴드의 공연 카드 클릭 시 그 공연의 공연 프로필로 이동하게 하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ❌ 이슈 닫기

> ex) close #70